### PR TITLE
WIP: 25.x Compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ Thumbs.db
 tmp/
 .cache/
 go-orchestrator/cli
+
+.specstory/

--- a/Justfile
+++ b/Justfile
@@ -141,6 +141,14 @@ install-panel:
 install-panel-win:
     scripts\\install-cep-panel-win.bat
 
+# Install UXP transcript bridge panel (macOS)
+install-uxp-panel:
+    bash ./scripts/install-uxp-panel.sh
+
+# Install UXP transcript bridge panel (Windows)
+install-uxp-panel-win:
+    scripts\\install-uxp-panel-win.bat
+
 # ─── Dev ───
 
 # Start all services in dev mode

--- a/cep-panel/src/CSInterface.js
+++ b/cep-panel/src/CSInterface.js
@@ -1,7 +1,7 @@
 /**************************************************************************************************
 *
 * ADOBE SYSTEMS INCORPORATED
-* Copyright 2013 Adobe Systems Incorporated
+* Copyright 2020 Adobe Systems Incorporated
 * All Rights Reserved.
 *
 * NOTICE:  Adobe permits you to use, modify, and distribute this file in accordance with the
@@ -11,14 +11,14 @@
 *
 **************************************************************************************************/
 
-/** CSInterface - v5.2.0 */
+/** CSInterface - v11.0.0 */
 
 /**
  * Stores constants for the window types supported by the CSXS infrastructure.
  */
 function CSXSWindowType()
 {
-};
+}
 
 /** Constant for the CSXS window type Panel. */
 CSXSWindowType._PANEL = "Panel";
@@ -51,7 +51,7 @@ function Version(major, minor, micro, special)
     this.minor = minor;
     this.micro = micro;
     this.special = special;
-};
+}
 
 /**
  * The maximum value allowed for a numeric version component.
@@ -73,7 +73,7 @@ function VersionBound(version, inclusive)
 {
     this.version = version;
     this.inclusive = inclusive;
-};
+}
 
 /**
  * @class VersionRange
@@ -88,7 +88,7 @@ function VersionRange(lowerBound, upperBound)
 {
     this.lowerBound = lowerBound;
     this.upperBound = upperBound;
-};
+}
 
 /**
  * @class Runtime
@@ -105,7 +105,7 @@ function Runtime(name, versionRange)
 {
     this.name = name;
     this.versionRange = versionRange;
-};
+}
 
 /**
 * @class Extension
@@ -150,7 +150,7 @@ function Extension(id, name, mainPath, basePath, windowType, width, height, minW
     this.requiredRuntimeList = requiredRuntimeList;
     this.isAutoVisible = isAutoVisible;
     this.isPluginExtension = isPluginExtension;
-};
+}
 
 /**
  * @class CSEvent
@@ -169,7 +169,7 @@ function CSEvent(type, scope, appId, extensionId)
     this.scope = scope;
     this.appId = appId;
     this.extensionId = extensionId;
-};
+}
 
 /** Event-specific data. */
 CSEvent.prototype.data = "";
@@ -182,7 +182,7 @@ CSEvent.prototype.data = "";
  */
 function SystemPath()
 {
-};
+}
 
 /** The path to user data.  */
 SystemPath.USER_DATA = "userData";
@@ -208,7 +208,7 @@ SystemPath.HOST_APPLICATION = "hostApplication";
  */
 function ColorType()
 {
-};
+}
 
 /** RGB color type. */
 ColorType.RGB = "rgb";
@@ -239,7 +239,7 @@ function RGBColor(red, green, blue, alpha)
     this.green = green;
     this.blue = blue;
     this.alpha = alpha;
-};
+}
 
 /**
  * @class Direction
@@ -257,7 +257,7 @@ function Direction(x, y)
 {
     this.x = x;
     this.y = y;
-};
+}
 
 /**
  * @class GradientStop
@@ -272,7 +272,7 @@ function GradientStop(offset, rgbColor)
 {
     this.offset = offset;
     this.rgbColor = rgbColor;
-};
+}
 
 /**
  * @class GradientColor
@@ -292,7 +292,7 @@ function GradientColor(type, direction, numStops, arrGradientStop)
     this.direction = direction;
     this.numStops = numStops;
     this.arrGradientStop = arrGradientStop;
-};
+}
 
 /**
  * @class UIColor
@@ -311,7 +311,7 @@ function UIColor(type, antialiasLevel, color)
     this.type = type;
     this.antialiasLevel = antialiasLevel;
     this.color = color;
-};
+}
 
 /**
  * @class AppSkinInfo
@@ -323,7 +323,7 @@ function UIColor(type, antialiasLevel, color)
  * @param panelBackgroundColor      The background color of the extension panel.
  * @param appBarBackgroundColorSRGB     The application bar background color, as sRGB.
  * @param panelBackgroundColorSRGB      The background color of the extension panel, as sRGB.
- * @param systemHighlightColor          The operating-system highlight color, as sRGB.
+ * @param systemHighlightColor          The highlight color of the extension panel, if provided by the host application. Otherwise, the operating-system highlight color.
  *
  * @return AppSkinInfo object.
  */
@@ -336,7 +336,7 @@ function AppSkinInfo(baseFontFamily, baseFontSize, appBarBackgroundColor, panelB
     this.appBarBackgroundColorSRGB = appBarBackgroundColorSRGB;
     this.panelBackgroundColorSRGB = panelBackgroundColorSRGB;
     this.systemHighlightColor = systemHighlightColor;
-};
+}
 
 /**
  * @class HostEnvironment
@@ -361,7 +361,7 @@ function HostEnvironment(appName, appVersion, appLocale, appUILocale, appId, isA
     this.appId = appId;
     this.isAppOnline = isAppOnline;
     this.appSkinInfo = appSkinInfo;
-};
+}
 
 /**
  * @class HostCapabilities
@@ -381,8 +381,8 @@ function HostCapabilities(EXTENDED_PANEL_MENU, EXTENDED_PANEL_ICONS, DELEGATE_AP
     this.EXTENDED_PANEL_ICONS = EXTENDED_PANEL_ICONS;
     this.DELEGATE_APE_ENGINE = DELEGATE_APE_ENGINE;
     this.SUPPORT_HTML_EXTENSIONS = SUPPORT_HTML_EXTENSIONS;
-	this.DISABLE_FLASH_EXTENSIONS = DISABLE_FLASH_EXTENSIONS; // Since 5.0.0
-};
+    this.DISABLE_FLASH_EXTENSIONS = DISABLE_FLASH_EXTENSIONS; // Since 5.0.0
+}
 
 /**
  * @class ApiVersion
@@ -401,7 +401,7 @@ function ApiVersion(major, minor, micro)
     this.major = major;
     this.minor = minor;
     this.micro = micro;
-};
+}
 
 /**
  * @class MenuItemStatus
@@ -410,17 +410,17 @@ function ApiVersion(major, minor, micro)
  * Since 5.2.0
  *
  * @param menuItemLabel  The menu item label.
- * @param enabled  		 True if user wants to enable the menu item.
- * @param checked  		 True if user wants to check the menu item.
+ * @param enabled        True if user wants to enable the menu item.
+ * @param checked        True if user wants to check the menu item.
  *
  * @return MenuItemStatus object.
  */
 function MenuItemStatus(menuItemLabel, enabled, checked)
 {
-	this.menuItemLabel = menuItemLabel;
-	this.enabled = enabled;
-	this.checked = checked;
-};
+    this.menuItemLabel = menuItemLabel;
+    this.enabled = enabled;
+    this.checked = checked;
+}
 
 /**
  * @class ContextMenuItemStatus
@@ -429,17 +429,17 @@ function MenuItemStatus(menuItemLabel, enabled, checked)
  * Since 5.2.0
  *
  * @param menuItemID     The menu item id.
- * @param enabled  		 True if user wants to enable the menu item.
- * @param checked  		 True if user wants to check the menu item.
+ * @param enabled        True if user wants to enable the menu item.
+ * @param checked        True if user wants to check the menu item.
  *
  * @return MenuItemStatus object.
  */
 function ContextMenuItemStatus(menuItemID, enabled, checked)
 {
-	this.menuItemID = menuItemID;
-	this.enabled = enabled;
-	this.checked = checked;
-};
+    this.menuItemID = menuItemID;
+    this.enabled = enabled;
+    this.checked = checked;
+}
 //------------------------------ CSInterface ----------------------------------
 
 /**
@@ -456,7 +456,7 @@ function ContextMenuItemStatus(menuItemID, enabled, checked)
  */
 function CSInterface()
 {
-};
+}
 
 /**
  * User can add this event listener to handle native application theme color changes.
@@ -477,7 +477,7 @@ function CSInterface()
 CSInterface.THEME_COLOR_CHANGED_EVENT = "com.adobe.csxs.events.ThemeColorChanged";
 
 /** The host environment data object. */
-CSInterface.prototype.hostEnvironment = JSON.parse(window.__adobe_cep__.getHostEnvironment());
+CSInterface.prototype.hostEnvironment = window.__adobe_cep__ ? JSON.parse(window.__adobe_cep__.getHostEnvironment()) : null;
 
 /** Retrieves information about the host environment in which the
  *  extension is currently running.
@@ -488,6 +488,89 @@ CSInterface.prototype.getHostEnvironment = function()
 {
     this.hostEnvironment = JSON.parse(window.__adobe_cep__.getHostEnvironment());
     return this.hostEnvironment;
+};
+
+/** Loads binary file created which is located at url asynchronously
+*
+*@param urlName url at which binary file is located. Local files should start with 'file://'
+*@param callback Optional. A callback function that returns after binary is loaded
+
+*@example
+* To create JS binary use command ./cep_compiler test.js test.bin
+* To load JS binary asyncronously
+*   var CSLib = new CSInterface();
+*   CSLib.loadBinAsync(url, function () { });
+*/
+CSInterface.prototype.loadBinAsync = function(urlName,callback)
+{
+    try
+    {
+        var xhr = new XMLHttpRequest();
+        xhr.responseType = 'arraybuffer'; // make response as ArrayBuffer
+        xhr.open('GET', urlName, true);
+        xhr.onerror = function ()
+        {
+  		  console.log("Unable to load snapshot from given URL");
+  		  return false;
+		};
+        xhr.send();
+        xhr.onload = () => {
+            window.__adobe_cep__.loadSnapshot(xhr.response);
+            if (typeof callback === "function")
+            {
+                callback();
+            }
+            else if(typeof callback !== "undefined")
+            {
+                console.log("Provided callback is not a function");
+            }
+        }
+    }
+    catch(err)
+    {
+        console.log(err);
+        return false;
+    }
+
+	return true;
+};
+
+/** Loads binary file created synchronously
+*
+*@param pathName the local path at which binary file is located
+
+*@example
+* To create JS binary use command ./cep_compiler test.js test.bin
+* To load JS binary syncronously
+*   var CSLib = new CSInterface();
+*   CSLib.loadBinSync(path);
+*/
+CSInterface.prototype.loadBinSync  = function(pathName)
+{
+    try
+    {
+        var OSVersion = this.getOSInformation();
+        if(pathName.startsWith("file://"))
+        {
+            if (OSVersion.indexOf("Windows") >= 0)
+            {
+               pathName = pathName.replace("file:///", "");
+            }
+            else if (OSVersion.indexOf("Mac") >= 0)
+            {
+                pathName = pathName.replace("file://", "");
+            }
+            window.__adobe_cep__.loadSnapshot(pathName);
+            return true;
+        }
+    }
+    catch(err)
+    {
+        console.log(err);
+        return false;
+    }
+    //control should not come here
+    return false;
 };
 
 /** Closes this extension. */
@@ -528,7 +611,7 @@ CSInterface.prototype.getSystemPath = function(pathType)
  */
 CSInterface.prototype.evalScript = function(script, callback)
 {
-    if(callback == null || callback == undefined)
+    if(callback === null || callback === undefined)
     {
         callback = function(result){};
     }
@@ -682,7 +765,7 @@ CSInterface.prototype.initResourceBundle = function()
            // Get all the resources that start with the key.
            for (var key in resourceBundle)
            {
-               if (key.indexOf(resKey) == 0)
+               if (key.indexOf(resKey) === 0)
                {
                    var resValue = resourceBundle[key];
                    if (key.length == resKey.length)
@@ -717,7 +800,7 @@ CSInterface.prototype.dumpInstallationInfo = function()
  *
  * @return A string containing the OS version, or "unknown Operation System".
  * If user customizes the User Agent by setting CEF command parameter "--user-agent", only
- * "Mac OS X" or "Windows" will be returned. 
+ * "Mac OS X" or "Windows" will be returned.
  */
 CSInterface.prototype.getOSInformation = function()
 {
@@ -731,55 +814,60 @@ CSInterface.prototype.getOSInformation = function()
         {
             if (userAgent.indexOf("Windows NT 5.0") > -1)
             {
-                winVersion = "Windows 2000 ";
+                winVersion = "Windows 2000";
             }
             else if (userAgent.indexOf("Windows NT 5.1") > -1)
             {
-                winVersion = "Windows XP ";
+                winVersion = "Windows XP";
             }
             else if (userAgent.indexOf("Windows NT 5.2") > -1)
             {
-                winVersion = "Windows Server 2003 ";
+                winVersion = "Windows Server 2003";
             }
             else if (userAgent.indexOf("Windows NT 6.0") > -1)
             {
-                winVersion = "Windows Vista ";
+                winVersion = "Windows Vista";
             }
             else if (userAgent.indexOf("Windows NT 6.1") > -1)
             {
-                winVersion = "Windows 7 ";
+                winVersion = "Windows 7";
             }
             else if (userAgent.indexOf("Windows NT 6.2") > -1)
             {
-                winVersion = "Windows 8 ";
+                winVersion = "Windows 8";
+            }
+            else if (userAgent.indexOf("Windows NT 6.3") > -1)
+            {
+                winVersion = "Windows 8.1";
+            }
+            else if (userAgent.indexOf("Windows NT 10") > -1)
+            {
+                winVersion = "Windows 10";
             }
 
-            if (userAgent.indexOf("WOW64") > -1)
+            if (userAgent.indexOf("WOW64") > -1 || userAgent.indexOf("Win64") > -1)
             {
-                winBit = "64-bit";
+                winBit = " 64-bit";
             }
             else
             {
-                winBit = "32-bit";			
+                winBit = " 32-bit";
             }
         }
 
         return winVersion + winBit;
     }
     else if ((navigator.platform == "MacIntel") || (navigator.platform == "Macintosh"))
-    {        
+    {
         var result = "Mac OS X";
-        var agentStr = new String();
-        agentStr = userAgent;
-        if (agentStr.indexOf("Mac OS X") > -1)
+
+        if (userAgent.indexOf("Mac OS X") > -1)
         {
-            var verLength = agentStr.indexOf(")") - agentStr.indexOf("Mac OS X");
-            var verStr = agentStr.substr(agentStr.indexOf("Mac OS X"), verLength);
-            result = verStr.replace("_", ".");
-            result = result.replace("_", ".");        
+            result = userAgent.substring(userAgent.indexOf("Mac OS X"), userAgent.indexOf(")"));
+            result = result.replace(/_/g, ".");
         }
 
-        return result;        
+        return result;
     }
 
     return "Unknown Operation System";
@@ -823,23 +911,38 @@ CSInterface.prototype.getExtensionID = function()
 };
 
 /**
- * Retrieves the scale factor of screen. 
+ * Retrieves the scale factor of screen.
  * On Windows platform, the value of scale factor might be different from operating system's scale factor,
  * since host application may use its self-defined scale factor.
  *
  * Since 4.2.0
  *
- * @return One of the following integer.
+ * @return One of the following float number.
  *      <ul>\n
- *          <li>-1 means fail to get scale factor or this API has not been available on Windows yet</li>\n
- *          <li>1 means normal screen</li>\n
- *          <li>2 means HiDPI screen</li>\n
+ *          <li> -1.0 when error occurs </li>\n
+ *          <li> 1.0 means normal screen </li>\n
+ *          <li> >1.0 means HiDPI screen </li>\n
  *      </ul>\n
  */
 CSInterface.prototype.getScaleFactor = function()
 {
     return window.__adobe_cep__.getScaleFactor();
 };
+
+/**
+ * Retrieves the scale factor of Monitor.
+ *
+ * Since 8.5.0
+ *
+ * @return value >= 1.0f
+ * only available for windows machine
+ */
+ if(navigator.appVersion.toLowerCase().indexOf("windows") >= 0) {
+    CSInterface.prototype.getMonitorScaleFactor = function()
+    {
+        return window.__adobe_cep__.getMonitorScaleFactor();
+    };
+}
 
 /**
  * Set a handler to detect any changes of scale factor. This only works on Mac.
@@ -873,9 +976,12 @@ CSInterface.prototype.getCurrentApiVersion = function()
  *
  * Since 5.2.0
  *
- * If user wants to be noticed when clicking an menu item, user needs to register "com.adobe.csxs.events.flyoutMenuClicked" Event by calling AddEventListener.
- * When an menu item is clicked, the event callback function will be called. 
- * The "data" attribute of event is an object which contains "menuId" and "menuName" attributes. 
+ * Register a callback function for "com.adobe.csxs.events.flyoutMenuClicked" to get notified when a
+ * menu item is clicked.
+ * The "data" attribute of event is an object which contains "menuId" and "menuName" attributes.
+ *
+ * Register callback functions for "com.adobe.csxs.events.flyoutMenuOpened" and "com.adobe.csxs.events.flyoutMenuClosed"
+ * respectively to get notified when flyout menu is opened or closed.
  *
  * @param menu     A XML string which describes menu structure.
  * An example menu XML:
@@ -896,36 +1002,36 @@ CSInterface.prototype.setPanelFlyoutMenu = function(menu)
 {
     if ("string" != typeof menu)
     {
-        return;	
+        return;
     }
 
-	window.__adobe_cep__.invokeSync("setPanelFlyoutMenu", menu);
+    window.__adobe_cep__.invokeSync("setPanelFlyoutMenu", menu);
 };
 
 /**
  * Updates a menu item in the extension window's flyout menu, by setting the enabled
  * and selection status.
- *  
+ *
  * Since 5.2.0
  *
- * @param menuItemLabel	The menu item label. 
- * @param enabled		True to enable the item, false to disable it (gray it out).
- * @param checked		True to select the item, false to deselect it.
+ * @param menuItemLabel The menu item label.
+ * @param enabled       True to enable the item, false to disable it (gray it out).
+ * @param checked       True to select the item, false to deselect it.
  *
- * @return false when the host application does not support this functionality (HostCapabilities.EXTENDED_PANEL_MENU is false). 
+ * @return false when the host application does not support this functionality (HostCapabilities.EXTENDED_PANEL_MENU is false).
  *         Fails silently if menu label is invalid.
  *
  * @see HostCapabilities.EXTENDED_PANEL_MENU
  */
 CSInterface.prototype.updatePanelMenuItem = function(menuItemLabel, enabled, checked)
 {
-	var ret = false;
-	if (this.getHostCapabilities().EXTENDED_PANEL_MENU) 
-	{
-		var itemStatus = new MenuItemStatus(menuItemLabel, enabled, checked);
-		ret = window.__adobe_cep__.invokeSync("updatePanelMenuItem", JSON.stringify(itemStatus));
-	}
-	return ret;
+    var ret = false;
+    if (this.getHostCapabilities().EXTENDED_PANEL_MENU)
+    {
+        var itemStatus = new MenuItemStatus(menuItemLabel, enabled, checked);
+        ret = window.__adobe_cep__.invokeSync("updatePanelMenuItem", JSON.stringify(itemStatus));
+    }
+    return ret;
 };
 
 
@@ -938,15 +1044,15 @@ CSInterface.prototype.updatePanelMenuItem = function(menuItemLabel, enabled, che
  * - an item without menu ID or menu name is disabled and is not shown.
  * - if the item name is "---" (three hyphens) then it is treated as a separator. The menu ID in this case will always be NULL.
  * - Checkable attribute takes precedence over Checked attribute.
- * - a PNG icon. For optimal display results please supply a 16 x 16px icon as larger dimensions will increase the size of the menu item. 
-     The Chrome extension contextMenus API was taken as a reference. 
+ * - a PNG icon. For optimal display results please supply a 16 x 16px icon as larger dimensions will increase the size of the menu item.
+     The Chrome extension contextMenus API was taken as a reference.
      https://developer.chrome.com/extensions/contextMenus
  * - the items with icons and checkable items cannot coexist on the same menu level. The former take precedences over the latter.
  *
  * @param menu      A XML string which describes menu structure.
  * @param callback  The callback function which is called when a menu item is clicked. The only parameter is the returned ID of clicked menu item.
  *
- * An example menu XML:
+ * @description An example menu XML:
  * <Menu>
  *   <MenuItem Id="menuItemId1" Label="TestExample1" Enabled="true" Checkable="true" Checked="false" Icon="./image/small_16X16.png"/>
  *   <MenuItem Id="menuItemId2" Label="TestExample2">
@@ -965,8 +1071,8 @@ CSInterface.prototype.setContextMenu = function(menu, callback)
     {
         return;
     }
-    
-	window.__adobe_cep__.invokeAsync("setContextMenu", menu, callback);
+
+    window.__adobe_cep__.invokeAsync("setContextMenu", menu, callback);
 };
 
 /**
@@ -978,7 +1084,7 @@ CSInterface.prototype.setContextMenu = function(menu, callback)
  * - an item without menu ID or menu name is disabled and is not shown.
  * - if the item label is "---" (three hyphens) then it is treated as a separator. The menu ID in this case will always be NULL.
  * - Checkable attribute takes precedence over Checked attribute.
- * - a PNG icon. For optimal display results please supply a 16 x 16px icon as larger dimensions will increase the size of the menu item. 
+ * - a PNG icon. For optimal display results please supply a 16 x 16px icon as larger dimensions will increase the size of the menu item.
      The Chrome extension contextMenus API was taken as a reference.
  * - the items with icons and checkable items cannot coexist on the same menu level. The former take precedences over the latter.
      https://developer.chrome.com/extensions/contextMenus
@@ -986,9 +1092,9 @@ CSInterface.prototype.setContextMenu = function(menu, callback)
  * @param menu      A JSON string which describes menu structure.
  * @param callback  The callback function which is called when a menu item is clicked. The only parameter is the returned ID of clicked menu item.
  *
- * An example menu JSON:
+ * @description An example menu JSON:
  *
- * { 
+ * {
  *      "menu": [
  *          {
  *              "id": "menuItemId1",
@@ -1021,7 +1127,7 @@ CSInterface.prototype.setContextMenu = function(menu, callback)
  *                      "enabled": true,
  *                      "checkable": true,
  *                      "checked": true
-                    }
+ *                  }
  *              ]
  *          },
  *          {
@@ -1042,43 +1148,43 @@ CSInterface.prototype.setContextMenuByJSON = function(menu, callback)
 {
     if ("string" != typeof menu)
     {
-        return;	
+        return;
     }
-    
-	window.__adobe_cep__.invokeAsync("setContextMenuByJSON", menu, callback);
+
+    window.__adobe_cep__.invokeAsync("setContextMenuByJSON", menu, callback);
 };
 
 /**
  * Updates a context menu item by setting the enabled and selection status.
- *  
+ *
  * Since 5.2.0
  *
- * @param menuItemID	The menu item ID. 
- * @param enabled		True to enable the item, false to disable it (gray it out).
- * @param checked		True to select the item, false to deselect it.
+ * @param menuItemID    The menu item ID.
+ * @param enabled       True to enable the item, false to disable it (gray it out).
+ * @param checked       True to select the item, false to deselect it.
  */
 CSInterface.prototype.updateContextMenuItem = function(menuItemID, enabled, checked)
 {
-	var itemStatus = new ContextMenuItemStatus(menuItemID, enabled, checked);
-	ret = window.__adobe_cep__.invokeSync("updateContextMenuItem", JSON.stringify(itemStatus));
+    var itemStatus = new ContextMenuItemStatus(menuItemID, enabled, checked);
+    ret = window.__adobe_cep__.invokeSync("updateContextMenuItem", JSON.stringify(itemStatus));
 };
 
 /**
- * Get the visibility status of an extension window. 
- *  
+ * Get the visibility status of an extension window.
+ *
  * Since 6.0.0
  *
  * @return true if the extension window is visible; false if the extension window is hidden.
  */
 CSInterface.prototype.isWindowVisible = function()
 {
-	return window.__adobe_cep__.invokeSync("isWindowVisible", "");
+    return window.__adobe_cep__.invokeSync("isWindowVisible", "");
 };
 
 /**
  * Resize extension's content to the specified dimensions.
  * 1. Works with modal and modeless extensions in all Adobe products.
- * 2. Extension's manifest min/max size constraints apply and take precedence. 
+ * 2. Extension's manifest min/max size constraints apply and take precedence.
  * 3. For panel extensions
  *    3.1 This works in all Adobe products except:
  *        * Premiere Pro
@@ -1096,4 +1202,90 @@ CSInterface.prototype.isWindowVisible = function()
 CSInterface.prototype.resizeContent = function(width, height)
 {
     window.__adobe_cep__.resizeContent(width, height);
+};
+
+/**
+ * Register the invalid certificate callback for an extension.
+ * This callback will be triggered when the extension tries to access the web site that contains the invalid certificate on the main frame.
+ * But if the extension does not call this function and tries to access the web site containing the invalid certificate, a default error page will be shown.
+ *
+ * Since 6.1.0
+ *
+ * @param callback the callback function
+ */
+CSInterface.prototype.registerInvalidCertificateCallback = function(callback)
+{
+    return window.__adobe_cep__.registerInvalidCertificateCallback(callback);
+};
+
+/**
+ * Register an interest in some key events to prevent them from being sent to the host application.
+ *
+ * This function works with modeless extensions and panel extensions.
+ * Generally all the key events will be sent to the host application for these two extensions if the current focused element
+ * is not text input or dropdown,
+ * If you want to intercept some key events and want them to be handled in the extension, please call this function
+ * in advance to prevent them being sent to the host application.
+ *
+ * Since 6.1.0
+ *
+ * @param keyEventsInterest      A JSON string describing those key events you are interested in. A null object or
+                                 an empty string will lead to removing the interest
+ *
+ * This JSON string should be an array, each object has following keys:
+ *
+ * keyCode:  [Required] represents an OS system dependent virtual key code identifying
+ *           the unmodified value of the pressed key.
+ * ctrlKey:  [optional] a Boolean that indicates if the control key was pressed (true) or not (false) when the event occurred.
+ * altKey:   [optional] a Boolean that indicates if the alt key was pressed (true) or not (false) when the event occurred.
+ * shiftKey: [optional] a Boolean that indicates if the shift key was pressed (true) or not (false) when the event occurred.
+ * metaKey:  [optional] (Mac Only) a Boolean that indicates if the Meta key was pressed (true) or not (false) when the event occurred.
+ *                      On Macintosh keyboards, this is the command key. To detect Windows key on Windows, please use keyCode instead.
+ * An example JSON string:
+ *
+ * [
+ *     {
+ *         "keyCode": 48
+ *     },
+ *     {
+ *         "keyCode": 123,
+ *         "ctrlKey": true
+ *     },
+ *     {
+ *         "keyCode": 123,
+ *         "ctrlKey": true,
+ *         "metaKey": true
+ *     }
+ * ]
+ *
+ */
+CSInterface.prototype.registerKeyEventsInterest = function(keyEventsInterest)
+{
+    return window.__adobe_cep__.registerKeyEventsInterest(keyEventsInterest);
+};
+
+/**
+ * Set the title of the extension window.
+ * This function works with modal and modeless extensions in all Adobe products, and panel extensions in Photoshop, InDesign, InCopy, Illustrator, Flash Pro and Dreamweaver.
+ *
+ * Since 6.1.0
+ *
+ * @param title The window title.
+ */
+CSInterface.prototype.setWindowTitle = function(title)
+{
+    window.__adobe_cep__.invokeSync("setWindowTitle", title);
+};
+
+/**
+ * Get the title of the extension window.
+ * This function works with modal and modeless extensions in all Adobe products, and panel extensions in Photoshop, InDesign, InCopy, Illustrator, Flash Pro and Dreamweaver.
+ *
+ * Since 6.1.0
+ *
+ * @return The window title.
+ */
+CSInterface.prototype.getWindowTitle = function()
+{
+    return window.__adobe_cep__.invokeSync("getWindowTitle", "");
 };

--- a/cep-panel/src/host/core.jsx
+++ b/cep-panel/src/host/core.jsx
@@ -29,7 +29,7 @@ if (typeof JSON === "undefined") {
     };
 }
 
-// ── Shared Helpers ────────────────────────────────────────────────────
+// -- Shared Helpers ----------------------------------------------------
 
 /**
  * Safely parse JSON arguments and validate required fields.
@@ -70,14 +70,14 @@ function _requireProject() {
 
 /**
  * Require an active sequence. Returns the sequence on success, or null.
- * If null, caller should return _err("No active sequence…").
+ * If null, caller should return _err("No active sequence...").
  */
 function _requireSequence() {
     if (!app.project) return null;
     return app.project.activeSequence || null;
 }
 
-// ── Project ───────────────────────────────────────────────────────────
+// -- Project -----------------------------------------------------------
 
 function ping() {
     try {
@@ -169,7 +169,7 @@ function closeProject(argsJson) {
     } catch (e) { return _err("Failed to close project: " + e.message); }
 }
 
-// ── Sequences ─────────────────────────────────────────────────────────
+// -- Sequences ---------------------------------------------------------
 
 function createSequence(argsJson) {
     try {
@@ -223,7 +223,7 @@ function getSequenceList() {
     } catch (e) { return _err("Failed to list sequences: " + e.message); }
 }
 
-// ── Media Import ──────────────────────────────────────────────────────
+// -- Media Import ------------------------------------------------------
 
 function importFiles(argsJson) {
     try {
@@ -271,7 +271,7 @@ function importFolder(argsJson) {
     } catch (e) { return _err("Failed to import folder '" + (folderPath || "unknown") + "': " + e.message); }
 }
 
-// ── Clips ─────────────────────────────────────────────────────────────
+// -- Clips -------------------------------------------------------------
 
 function getTimelineState(argsJson) {
     try {
@@ -408,7 +408,7 @@ function placeClip(argsJson) {
     } catch (e) { return _err("Failed to place clip: " + e.message); }
 }
 
-// ── Export ─────────────────────────────────────────────────────────────
+// -- Export -------------------------------------------------------------
 
 function exportSequence(argsJson) {
     try {
@@ -423,7 +423,7 @@ function exportSequence(argsJson) {
     } catch (e) { return _err("Failed to export sequence: " + e.message); }
 }
 
-// ── Bins ──────────────────────────────────────────────────────────────
+// -- Bins --------------------------------------------------------------
 
 function createBin(argsJson) {
     try {
@@ -460,7 +460,7 @@ function getProjectItems(argsJson) {
     } catch (e) { return _err("Failed to get project items: " + e.message); }
 }
 
-// ── Markers ───────────────────────────────────────────────────────────
+// -- Markers -----------------------------------------------------------
 
 function addSequenceMarker(argsJson) {
     try {
@@ -480,7 +480,7 @@ function addSequenceMarker(argsJson) {
     } catch (e) { return _err("Failed to add sequence marker: " + e.message); }
 }
 
-// ── Playback ──────────────────────────────────────────────────────────
+// -- Playback ----------------------------------------------------------
 
 function getPlayheadPosition() {
     try {
@@ -508,7 +508,7 @@ function setPlayheadPosition(argsJson) {
     } catch (e) { return _err("Failed to set playhead to " + (args && args.seconds !== undefined ? args.seconds + "s" : "unknown position") + ": " + e.message); }
 }
 
-// ── Audio ─────────────────────────────────────────────────────────────
+// -- Audio -------------------------------------------------------------
 
 function setAudioLevel(argsJson) {
     try {
@@ -548,7 +548,7 @@ function setAudioLevel(argsJson) {
     } catch (e) { return _err("Failed to set audio level: " + e.message); }
 }
 
-// ── Effects ───────────────────────────────────────────────────────────
+// -- Effects -----------------------------------------------------------
 
 function getClipEffects(argsJson) {
     try {
@@ -594,7 +594,7 @@ function getClipEffects(argsJson) {
     } catch (e) { return _err("Failed to get clip effects: " + e.message); }
 }
 
-// ── Transitions (QE DOM) ──────────────────────────────────────────────
+// -- Transitions (QE DOM) ----------------------------------------------
 
 function addVideoTransition(argsJson) {
     try {
@@ -629,7 +629,7 @@ function addVideoTransition(argsJson) {
     } catch (e) { return _err("Failed to add transition: " + e.message); }
 }
 
-// ── Color ─────────────────────────────────────────────────────────────
+// -- Color -------------------------------------------------------------
 
 function setLumetriProperty(argsJson) {
     try {
@@ -684,7 +684,7 @@ function setLumetriProperty(argsJson) {
     } catch (e) { return _err("Failed to set Lumetri property '" + (args && args.property ? args.property : "unknown") + "': " + e.message); }
 }
 
-// ── Motion ────────────────────────────────────────────────────────────
+// -- Motion ------------------------------------------------------------
 
 function setPosition(argsJson) {
     try {
@@ -787,7 +787,7 @@ function setOpacity(argsJson) {
     } catch (e) { return _err("Failed to set opacity: " + e.message); }
 }
 
-// ── System ────────────────────────────────────────────────────────────
+// -- System ------------------------------------------------------------
 
 function getSystemInfo() {
     try {
@@ -801,7 +801,7 @@ function getSystemInfo() {
     } catch (e) { return _err("Failed to get system info: " + e.message); }
 }
 
-// ── Tool Categories (for discoverability) ─────────────────────────────
+// -- Tool Categories (for discoverability) -----------------------------
 
 function getToolCategories() {
     return _ok({
@@ -831,7 +831,7 @@ function getToolCategories() {
     });
 }
 
-// ── Media Browser ─────────────────────────────────────────────────────
+// -- Media Browser -----------------------------------------------------
 
 function browsePath(argsJson) {
     try {
@@ -944,7 +944,7 @@ function getRecentLocations() {
     } catch (e) { return _err("Failed to get recent locations: " + e.message); }
 }
 
-// ── Timeline Panel Menu Items ─────────────────────────────────────────
+// -- Timeline Panel Menu Items -----------------------------------------
 
 function setAudioWaveformLabelColor(argsJson) {
     try {
@@ -1097,7 +1097,7 @@ function setRectifiedAudioWaveforms(argsJson) {
     } catch (e) { return _err("Failed to set rectified audio waveforms: " + e.message); }
 }
 
-// ── Frame Capture ─────────────────────────────────────────────────────
+// -- Frame Capture -----------------------------------------------------
 
 function captureFrameAsBase64(argsJson) {
     try {
@@ -1167,7 +1167,7 @@ function _binaryToBase64(data) {
     return result;
 }
 
-// ── Secure Script Execution ───────────────────────────────────────────
+// -- Secure Script Execution -------------------------------------------
 
 function executeSecureScript(argsJson) {
     try {
@@ -1203,7 +1203,7 @@ function executeQEScript(argsJson) {
     } catch (e) { return _err("Failed to execute QE script: " + e.message); }
 }
 
-// ── Panel Docking via macOS Accessibility (AppleScript) ───────────────
+// -- Panel Docking via macOS Accessibility (AppleScript) ---------------
 
 function simulateMenuClick(argsJson) {
     try {

--- a/cep-panel/src/host/core.jsx
+++ b/cep-panel/src/host/core.jsx
@@ -1233,3 +1233,109 @@ function simulateMenuClick(argsJson) {
         return _ok({ message: "Menu clicked: " + menuPath });
     } catch (e) { return _err("Failed to simulate menu click '" + (args && args.menu_path ? args.menu_path : "unknown") + "': " + e.message); }
 }
+
+// ---------------------------------------------------------------------------
+// Sequence markers (in core so EvalCommand works even if premiere.jsx fails to load)
+// ---------------------------------------------------------------------------
+
+function _mcpMarkerCommentCore(m) {
+    try {
+        if (m.comments !== undefined && m.comments !== null) return String(m.comments);
+    } catch (e0) {}
+    try {
+        if (m.comment !== undefined && m.comment !== null) return String(m.comment);
+    } catch (e1) {}
+    return "";
+}
+function _mcpMarkerTypeCore(m) {
+    try {
+        return String(m.type !== undefined && m.type !== null ? m.type : "");
+    } catch (e) {
+        return "";
+    }
+}
+function _mcpMarkerColorIndexCore(m) {
+    try {
+        var c = m.colorIndex;
+        if (c === undefined || c === null) return -1;
+        var n = parseInt(c, 10);
+        return isNaN(n) ? -1 : n;
+    } catch (e2) {
+        return -1;
+    }
+}
+function _mcpTimeToSecondsCore(timeObj) {
+    if (!timeObj) return 0;
+    try {
+        return parseFloat(timeObj.seconds);
+    } catch (e) {
+        return 0;
+    }
+}
+
+function getSequenceMarkers() {
+    try {
+        if (!app.project) {
+            return _err("No project is open");
+        }
+        var seq = app.project.activeSequence;
+        if (!seq) {
+            return _err("No active sequence");
+        }
+        var markers = [];
+        var mc = seq.markers;
+        if (mc) {
+            var max = 0;
+            try {
+                max = parseInt(mc.numMarkers, 10) || 0;
+            } catch (eCt) {
+                max = 0;
+            }
+            var vm;
+            for (vm = 0; vm < max; vm++) {
+                try {
+                    var marker = mc[vm];
+                    if (!marker) {
+                        continue;
+                    }
+                    var mname = "";
+                    try {
+                        mname = String(marker.name !== undefined && marker.name !== null ? marker.name : "");
+                    } catch (en) {
+                        mname = "";
+                    }
+                    markers.push({
+                        index: vm,
+                        name: mname,
+                        comment: _mcpMarkerCommentCore(marker),
+                        start: _mcpTimeToSecondsCore(marker.start),
+                        end: _mcpTimeToSecondsCore(marker.end),
+                        type: _mcpMarkerTypeCore(marker),
+                        color_index: _mcpMarkerColorIndexCore(marker)
+                    });
+                } catch (one) {
+                }
+            }
+        }
+        var sn = "";
+        var sid = "";
+        try {
+            sn = String(seq.name || "");
+        } catch (esn) {
+            sn = "";
+        }
+        try {
+            sid = String(seq.sequenceID || "");
+        } catch (esi) {
+            sid = "";
+        }
+        return _ok({
+            count: markers.length,
+            markers: markers,
+            sequence_name: sn,
+            sequence_id: sid
+        });
+    } catch (e) {
+        return _err("getSequenceMarkers failed: " + e.message);
+    }
+}

--- a/cep-panel/src/host/core.jsx
+++ b/cep-panel/src/host/core.jsx
@@ -212,14 +212,25 @@ function getSequenceList() {
         if (!app.project) return _err("No project is open.");
         var seqs = [];
         var numSeqs = 0;
-        try { numSeqs = app.project.sequences.numItems; } catch (e1) {}
+        try { numSeqs = app.project.sequences.numSequences || app.project.sequences.numItems || 0; } catch (e1) {}
+        var activeID = app.project.activeSequence ? (app.project.activeSequence.sequenceID || "") : "";
         for (var i = 0; i < numSeqs; i++) {
             var s = app.project.sequences[i];
             if (s) {
-                seqs.push({ index: i, name: s.name, id: s.sequenceID });
+                seqs.push({
+                    index: i,
+                    name: s.name || "",
+                    sequence_id: s.sequenceID || "",
+                    frame_size_horizontal: s.frameSizeHorizontal || 0,
+                    frame_size_vertical: s.frameSizeVertical || 0,
+                    timebase: s.timebase || "",
+                    video_track_count: (s.videoTracks && s.videoTracks.numTracks !== undefined) ? s.videoTracks.numTracks : 0,
+                    audio_track_count: (s.audioTracks && s.audioTracks.numTracks !== undefined) ? s.audioTracks.numTracks : 0,
+                    is_active: (s.sequenceID === activeID)
+                });
             }
         }
-        return _ok({ sequences: seqs, count: seqs.length });
+        return _ok({ sequences: seqs, count: seqs.length, active_sequence_id: activeID });
     } catch (e) { return _err("Failed to list sequences: " + e.message); }
 }
 

--- a/cep-panel/src/host/core.jsx
+++ b/cep-panel/src/host/core.jsx
@@ -53,6 +53,24 @@ function _parseArgs(argsJson, requiredFields) {
 }
 
 /**
+ * Major release number from app.version (e.g. 24, 25) for PP24 vs PP25 compatibility branches.
+ */
+function _premiereMajorVersion() {
+    try {
+        var v = app.version || "";
+        var m = v.match(/^(\d+)/);
+        return m ? parseInt(m[1], 10) : 0;
+    } catch (e) {
+        return 0;
+    }
+}
+
+/** True when Premiere major >= minMajor (release-family gate). */
+function _premiereAtLeastMajor(minMajor) {
+    return _premiereMajorVersion() >= minMajor;
+}
+
+/**
  * Return the active sequence or null, guarding against app.project being null.
  */
 function _getActiveSequence() {

--- a/cep-panel/src/host/premiere.jsx
+++ b/cep-panel/src/host/premiere.jsx
@@ -1795,20 +1795,20 @@ function getSequenceList() {
             sequences.push({
                 index: i,
                 name: seq.name || "",
-                sequenceID: seq.sequenceID || "",
-                frameSizeHorizontal: seq.frameSizeHorizontal || 0,
-                frameSizeVertical: seq.frameSizeVertical || 0,
+                sequence_id: seq.sequenceID || "",
+                frame_size_horizontal: seq.frameSizeHorizontal || 0,
+                frame_size_vertical: seq.frameSizeVertical || 0,
                 timebase: seq.timebase || "",
-                videoTrackCount: seq.videoTracks ? seq.videoTracks.numTracks : 0,
-                audioTrackCount: seq.audioTracks ? seq.audioTracks.numTracks : 0,
-                isActive: (seq.sequenceID === activeID)
+                video_track_count: seq.videoTracks ? seq.videoTracks.numTracks : 0,
+                audio_track_count: seq.audioTracks ? seq.audioTracks.numTracks : 0,
+                is_active: seq.sequenceID === activeID,
             });
         }
 
         return _ok({
             count: sequences.length,
             sequences: sequences,
-            activeSequenceID: activeID
+            active_sequence_id: activeID,
         });
     } catch (e) {
         return _err("getSequenceList failed: " + e.message);

--- a/cep-panel/src/host/premiere.jsx
+++ b/cep-panel/src/host/premiere.jsx
@@ -105,6 +105,21 @@ function _secondsToTime(seconds) {
     return t;
 }
 
+/**
+ * CEP bridge calls evalScript("fn('{...JSON...}')") with a SINGLE string argument,
+ * while many handlers below declare separate parameters. Detect and unwrap.
+ */
+function _tryParseJSONObjectString(v) {
+    if (v === undefined || v === null || v === "") return null;
+    var s = String(v).replace(/^\s+|\s+$/g, "");
+    if (s.charAt(0) !== "{") return null;
+    try {
+        var o = JSON.parse(s);
+        if (typeof o === "object" && o !== null && !(o instanceof Array)) return o;
+    } catch (eIgnored) {}
+    return null;
+}
+
 // ---------------------------------------------------------------------------
 // ping() - Health check
 // ---------------------------------------------------------------------------
@@ -2723,6 +2738,13 @@ function getClipInfo(trackType, trackIndex, clipIndex) {
 // ---------------------------------------------------------------------------
 function getClipsOnTrack(trackType, trackIndex) {
     try {
+        var argObj = _tryParseJSONObjectString(trackType);
+        if (argObj) {
+            trackType = argObj.trackType || argObj.track_type;
+            if (argObj.trackIndex !== undefined || argObj.track_index !== undefined) {
+                trackIndex = argObj.trackIndex !== undefined ? argObj.trackIndex : argObj.track_index;
+            }
+        }
         if (!app.project) return _err("No project is open");
         var seq = app.project.activeSequence;
         if (!seq) return _err("No active sequence");
@@ -5159,6 +5181,11 @@ function importMOGRT(mogrtPath, timeTicks, videoTrackOffset, audioTrackOffset) {
 
 function getMOGRTProperties(trackIndex, clipIndex) {
     try {
+        var mobj = _tryParseJSONObjectString(trackIndex);
+        if (mobj) {
+            trackIndex = mobj.trackIndex !== undefined ? mobj.trackIndex : mobj.track_index;
+            clipIndex = mobj.clipIndex !== undefined ? mobj.clipIndex : mobj.clip_index;
+        }
         if (!app.project) return _err("No project is open");
         var seq = app.project.activeSequence;
         if (!seq) return _err("No active sequence");
@@ -5186,6 +5213,14 @@ function getMOGRTProperties(trackIndex, clipIndex) {
 
 function setMOGRTText(trackIndex, clipIndex, propertyIndex, text) {
     try {
+        var tobj = _tryParseJSONObjectString(trackIndex);
+        if (tobj) {
+            trackIndex = tobj.trackIndex !== undefined ? tobj.trackIndex : tobj.track_index;
+            clipIndex = tobj.clipIndex !== undefined ? tobj.clipIndex : tobj.clip_index;
+            propertyIndex =
+                tobj.propertyIndex !== undefined ? tobj.propertyIndex : tobj.property_index;
+            text = tobj.text !== undefined ? String(tobj.text) : "";
+        }
         if (!app.project) return _err("No project is open");
         var seq = app.project.activeSequence;
         if (!seq) return _err("No active sequence");
@@ -5207,6 +5242,14 @@ function setMOGRTText(trackIndex, clipIndex, propertyIndex, text) {
 
 function setMOGRTProperty(trackIndex, clipIndex, propertyName, value) {
     try {
+        var pobj = _tryParseJSONObjectString(trackIndex);
+        if (pobj) {
+            trackIndex = pobj.trackIndex !== undefined ? pobj.trackIndex : pobj.track_index;
+            clipIndex = pobj.clipIndex !== undefined ? pobj.clipIndex : pobj.clip_index;
+            propertyName =
+                pobj.propertyName !== undefined ? pobj.propertyName : pobj.property_name;
+            value = pobj.value !== undefined ? String(pobj.value) : "";
+        }
         if (!app.project) return _err("No project is open");
         var seq = app.project.activeSequence;
         if (!seq) return _err("No active sequence");

--- a/cep-panel/src/host/premiere.jsx
+++ b/cep-panel/src/host/premiere.jsx
@@ -2251,49 +2251,7 @@ function insertBarsAndTone(paramsJson) {
     }
 }
 
-// ---------------------------------------------------------------------------
-// getSequenceMarkers() - Get all markers on the active sequence
-// ---------------------------------------------------------------------------
-function getSequenceMarkers() {
-    try {
-        if (!app.project) {
-            return _err("No project is open");
-        }
-
-        var seq = app.project.activeSequence;
-        if (!seq) {
-            return _err("No active sequence");
-        }
-
-        var markers = [];
-        if (seq.markers) {
-            var marker = seq.markers.getFirstMarker();
-            var idx = 0;
-            while (marker) {
-                markers.push({
-                    index: idx,
-                    name: marker.name || "",
-                    comment: marker.comments || "",
-                    start: _timeToSeconds(marker.start),
-                    end: _timeToSeconds(marker.end),
-                    type: marker.type || "",
-                    colorIndex: marker.colorIndex !== undefined ? marker.colorIndex : -1
-                });
-                idx++;
-                marker = seq.markers.getNextMarker(marker);
-            }
-        }
-
-        return _ok({
-            count: markers.length,
-            markers: markers,
-            sequenceName: seq.name || "",
-            sequenceID: seq.sequenceID || ""
-        });
-    } catch (e) {
-        return _err("getSequenceMarkers failed: " + e.message);
-    }
-}
+// getSequenceMarkers — implemented in core.jsx (always loaded); keeps EvalCommand working if premiere.jsx fails to $.evalFile.
 
 // ---------------------------------------------------------------------------
 // addSequenceMarker(paramsJson) - Add a marker to the active sequence

--- a/cep-panel/src/host/premiere.jsx
+++ b/cep-panel/src/host/premiere.jsx
@@ -2266,49 +2266,7 @@ function insertBarsAndTone(paramsJson) {
     }
 }
 
-// ---------------------------------------------------------------------------
-// getSequenceMarkers() - Get all markers on the active sequence
-// ---------------------------------------------------------------------------
-function getSequenceMarkers() {
-    try {
-        if (!app.project) {
-            return _err("No project is open");
-        }
-
-        var seq = app.project.activeSequence;
-        if (!seq) {
-            return _err("No active sequence");
-        }
-
-        var markers = [];
-        if (seq.markers) {
-            var marker = seq.markers.getFirstMarker();
-            var idx = 0;
-            while (marker) {
-                markers.push({
-                    index: idx,
-                    name: marker.name || "",
-                    comment: marker.comments || "",
-                    start: _timeToSeconds(marker.start),
-                    end: _timeToSeconds(marker.end),
-                    type: marker.type || "",
-                    colorIndex: marker.colorIndex !== undefined ? marker.colorIndex : -1
-                });
-                idx++;
-                marker = seq.markers.getNextMarker(marker);
-            }
-        }
-
-        return _ok({
-            count: markers.length,
-            markers: markers,
-            sequenceName: seq.name || "",
-            sequenceID: seq.sequenceID || ""
-        });
-    } catch (e) {
-        return _err("getSequenceMarkers failed: " + e.message);
-    }
-}
+// getSequenceMarkers — implemented in core.jsx (always loaded); keeps EvalCommand working if premiere.jsx fails to $.evalFile.
 
 // ---------------------------------------------------------------------------
 // addSequenceMarker(paramsJson) - Add a marker to the active sequence

--- a/cep-panel/src/host/premiere.jsx
+++ b/cep-panel/src/host/premiere.jsx
@@ -4761,7 +4761,7 @@ function setLumetriTint(trackIndex, clipIndex, value) { try { return _setLumetri
 function setLumetriExposure(trackIndex, clipIndex, value) { try { return _setLumetriProperty(trackIndex, clipIndex, "Exposure", value); } catch (e) { return _err("setLumetriExposure failed: " + e.message); } }
 
 // ---------------------------------------------------------------------------
-// Lumetri Color — Extended (Comprehensive Color Correction)
+// Lumetri Color - Extended (Comprehensive Color Correction)
 // ---------------------------------------------------------------------------
 
 /**
@@ -4814,7 +4814,7 @@ function _getLumetriComponent(trackIndex, clipIndex) {
     return lumetri;
 }
 
-/** 1. lumetriGetAll — Get all Lumetri Color parameter values */
+/** 1. lumetriGetAll - Get all Lumetri Color parameter values */
 function lumetriGetAll(trackIndex, clipIndex) {
     try {
         if (!app.project) return _err("No project is open");
@@ -4849,67 +4849,67 @@ function lumetriGetAll(trackIndex, clipIndex) {
     } catch (e) { return _err("lumetriGetAll failed: " + e.message); }
 }
 
-/** 2. lumetriSetExposure — Set exposure (-4.0 to 4.0) */
+/** 2. lumetriSetExposure - Set exposure (-4.0 to 4.0) */
 function lumetriSetExposure(trackIndex, clipIndex, value) {
     try { value = Math.max(-4.0, Math.min(4.0, parseFloat(value) || 0)); return _setLumetriProperty(trackIndex, clipIndex, "Exposure", value); } catch (e) { return _err("lumetriSetExposure failed: " + e.message); }
 }
 
-/** 3. lumetriSetContrast — Set contrast (-100 to 100) */
+/** 3. lumetriSetContrast - Set contrast (-100 to 100) */
 function lumetriSetContrast(trackIndex, clipIndex, value) {
     try { value = Math.max(-100, Math.min(100, parseFloat(value) || 0)); return _setLumetriProperty(trackIndex, clipIndex, "Contrast", value); } catch (e) { return _err("lumetriSetContrast failed: " + e.message); }
 }
 
-/** 4. lumetriSetHighlights — Set highlights (-100 to 100) */
+/** 4. lumetriSetHighlights - Set highlights (-100 to 100) */
 function lumetriSetHighlights(trackIndex, clipIndex, value) {
     try { value = Math.max(-100, Math.min(100, parseFloat(value) || 0)); return _setLumetriProperty(trackIndex, clipIndex, "Highlights", value); } catch (e) { return _err("lumetriSetHighlights failed: " + e.message); }
 }
 
-/** 5. lumetriSetShadows — Set shadows (-100 to 100) */
+/** 5. lumetriSetShadows - Set shadows (-100 to 100) */
 function lumetriSetShadows(trackIndex, clipIndex, value) {
     try { value = Math.max(-100, Math.min(100, parseFloat(value) || 0)); return _setLumetriProperty(trackIndex, clipIndex, "Shadows", value); } catch (e) { return _err("lumetriSetShadows failed: " + e.message); }
 }
 
-/** 6. lumetriSetWhites — Set whites (-100 to 100) */
+/** 6. lumetriSetWhites - Set whites (-100 to 100) */
 function lumetriSetWhites(trackIndex, clipIndex, value) {
     try { value = Math.max(-100, Math.min(100, parseFloat(value) || 0)); return _setLumetriProperty(trackIndex, clipIndex, "Whites", value); } catch (e) { return _err("lumetriSetWhites failed: " + e.message); }
 }
 
-/** 7. lumetriSetBlacks — Set blacks (-100 to 100) */
+/** 7. lumetriSetBlacks - Set blacks (-100 to 100) */
 function lumetriSetBlacks(trackIndex, clipIndex, value) {
     try { value = Math.max(-100, Math.min(100, parseFloat(value) || 0)); return _setLumetriProperty(trackIndex, clipIndex, "Blacks", value); } catch (e) { return _err("lumetriSetBlacks failed: " + e.message); }
 }
 
-/** 8. lumetriSetTemperature — Set white balance temperature */
+/** 8. lumetriSetTemperature - Set white balance temperature */
 function lumetriSetTemperature(trackIndex, clipIndex, value) {
     try { value = parseFloat(value) || 0; return _setLumetriProperty(trackIndex, clipIndex, "Temperature", value); } catch (e) { return _err("lumetriSetTemperature failed: " + e.message); }
 }
 
-/** 9. lumetriSetTint — Set white balance tint */
+/** 9. lumetriSetTint - Set white balance tint */
 function lumetriSetTint(trackIndex, clipIndex, value) {
     try { value = parseFloat(value) || 0; return _setLumetriProperty(trackIndex, clipIndex, "Tint", value); } catch (e) { return _err("lumetriSetTint failed: " + e.message); }
 }
 
-/** 10. lumetriSetSaturation — Set saturation (0 to 200) */
+/** 10. lumetriSetSaturation - Set saturation (0 to 200) */
 function lumetriSetSaturation(trackIndex, clipIndex, value) {
     try { value = Math.max(0, Math.min(200, parseFloat(value) || 100)); return _setLumetriProperty(trackIndex, clipIndex, "Saturation", value); } catch (e) { return _err("lumetriSetSaturation failed: " + e.message); }
 }
 
-/** 11. lumetriSetVibrance — Set vibrance (-100 to 100) */
+/** 11. lumetriSetVibrance - Set vibrance (-100 to 100) */
 function lumetriSetVibrance(trackIndex, clipIndex, value) {
     try { value = Math.max(-100, Math.min(100, parseFloat(value) || 0)); return _setLumetriProperty(trackIndex, clipIndex, "Vibrance", value); } catch (e) { return _err("lumetriSetVibrance failed: " + e.message); }
 }
 
-/** 12. lumetriSetFadedFilm — Set faded film amount (0 to 100) */
+/** 12. lumetriSetFadedFilm - Set faded film amount (0 to 100) */
 function lumetriSetFadedFilm(trackIndex, clipIndex, value) {
     try { value = Math.max(0, Math.min(100, parseFloat(value) || 0)); return _setLumetriProperty(trackIndex, clipIndex, "Faded Film", value); } catch (e) { return _err("lumetriSetFadedFilm failed: " + e.message); }
 }
 
-/** 13. lumetriSetSharpen — Set sharpening (0 to 200) */
+/** 13. lumetriSetSharpen - Set sharpening (0 to 200) */
 function lumetriSetSharpen(trackIndex, clipIndex, value) {
     try { value = Math.max(0, Math.min(200, parseFloat(value) || 0)); return _setLumetriProperty(trackIndex, clipIndex, "Sharpen", value); } catch (e) { return _err("lumetriSetSharpen failed: " + e.message); }
 }
 
-/** 14. lumetriSetCurvePoint — Set a point on RGB/Luma curve (channel: luma/red/green/blue) */
+/** 14. lumetriSetCurvePoint - Set a point on RGB/Luma curve (channel: luma/red/green/blue) */
 function lumetriSetCurvePoint(trackIndex, clipIndex, channel, inputValue, outputValue) {
     try {
         if (!app.project) return _err("No project is open");
@@ -4930,7 +4930,7 @@ function lumetriSetCurvePoint(trackIndex, clipIndex, channel, inputValue, output
     } catch (e) { return _err("lumetriSetCurvePoint failed: " + e.message); }
 }
 
-/** 15. lumetriSetShadowColor — Set shadow color wheel */
+/** 15. lumetriSetShadowColor - Set shadow color wheel */
 function lumetriSetShadowColor(trackIndex, clipIndex, hue, saturation, brightness) {
     try {
         if (!app.project) return _err("No project is open");
@@ -4945,7 +4945,7 @@ function lumetriSetShadowColor(trackIndex, clipIndex, hue, saturation, brightnes
     } catch (e) { return _err("lumetriSetShadowColor failed: " + e.message); }
 }
 
-/** 16. lumetriSetMidtoneColor — Set midtone color wheel */
+/** 16. lumetriSetMidtoneColor - Set midtone color wheel */
 function lumetriSetMidtoneColor(trackIndex, clipIndex, hue, saturation, brightness) {
     try {
         if (!app.project) return _err("No project is open");
@@ -4960,7 +4960,7 @@ function lumetriSetMidtoneColor(trackIndex, clipIndex, hue, saturation, brightne
     } catch (e) { return _err("lumetriSetMidtoneColor failed: " + e.message); }
 }
 
-/** 17. lumetriSetHighlightColor — Set highlight color wheel */
+/** 17. lumetriSetHighlightColor - Set highlight color wheel */
 function lumetriSetHighlightColor(trackIndex, clipIndex, hue, saturation, brightness) {
     try {
         if (!app.project) return _err("No project is open");
@@ -4975,27 +4975,27 @@ function lumetriSetHighlightColor(trackIndex, clipIndex, hue, saturation, bright
     } catch (e) { return _err("lumetriSetHighlightColor failed: " + e.message); }
 }
 
-/** 18. lumetriSetVignetteAmount — Set vignette amount */
+/** 18. lumetriSetVignetteAmount - Set vignette amount */
 function lumetriSetVignetteAmount(trackIndex, clipIndex, value) {
     try { value = Math.max(-5, Math.min(5, parseFloat(value) || 0)); return _setLumetriProperty(trackIndex, clipIndex, "Vignette Amount", value); } catch (e) { return _err("lumetriSetVignetteAmount failed: " + e.message); }
 }
 
-/** 19. lumetriSetVignetteMidpoint — Set vignette midpoint */
+/** 19. lumetriSetVignetteMidpoint - Set vignette midpoint */
 function lumetriSetVignetteMidpoint(trackIndex, clipIndex, value) {
     try { value = Math.max(0, Math.min(100, parseFloat(value) || 50)); return _setLumetriProperty(trackIndex, clipIndex, "Vignette Midpoint", value); } catch (e) { return _err("lumetriSetVignetteMidpoint failed: " + e.message); }
 }
 
-/** 20. lumetriSetVignetteRoundness — Set vignette roundness */
+/** 20. lumetriSetVignetteRoundness - Set vignette roundness */
 function lumetriSetVignetteRoundness(trackIndex, clipIndex, value) {
     try { value = Math.max(-100, Math.min(100, parseFloat(value) || 0)); return _setLumetriProperty(trackIndex, clipIndex, "Vignette Roundness", value); } catch (e) { return _err("lumetriSetVignetteRoundness failed: " + e.message); }
 }
 
-/** 21. lumetriSetVignetteFeather — Set vignette feather */
+/** 21. lumetriSetVignetteFeather - Set vignette feather */
 function lumetriSetVignetteFeather(trackIndex, clipIndex, value) {
     try { value = Math.max(0, Math.min(100, parseFloat(value) || 50)); return _setLumetriProperty(trackIndex, clipIndex, "Vignette Feather", value); } catch (e) { return _err("lumetriSetVignetteFeather failed: " + e.message); }
 }
 
-/** 22. lumetriApplyLUT — Apply a LUT file (.cube, .3dl) */
+/** 22. lumetriApplyLUT - Apply a LUT file (.cube, .3dl) */
 function lumetriApplyLUT(trackIndex, clipIndex, lutPath) {
     try {
         if (!app.project) return _err("No project is open");
@@ -5013,7 +5013,7 @@ function lumetriApplyLUT(trackIndex, clipIndex, lutPath) {
     } catch (e) { return _err("lumetriApplyLUT failed: " + e.message); }
 }
 
-/** 23. lumetriRemoveLUT — Remove applied LUT */
+/** 23. lumetriRemoveLUT - Remove applied LUT */
 function lumetriRemoveLUT(trackIndex, clipIndex) {
     try {
         if (!app.project) return _err("No project is open");
@@ -5025,7 +5025,7 @@ function lumetriRemoveLUT(trackIndex, clipIndex) {
     } catch (e) { return _err("lumetriRemoveLUT failed: " + e.message); }
 }
 
-/** 24. lumetriAutoColor — Auto color correction (applies reasonable defaults) */
+/** 24. lumetriAutoColor - Auto color correction (applies reasonable defaults) */
 function lumetriAutoColor(trackIndex, clipIndex) {
     try {
         if (!app.project) return _err("No project is open");
@@ -5038,7 +5038,7 @@ function lumetriAutoColor(trackIndex, clipIndex) {
     } catch (e) { return _err("lumetriAutoColor failed: " + e.message); }
 }
 
-/** 25. lumetriReset — Reset all Lumetri settings to default */
+/** 25. lumetriReset - Reset all Lumetri settings to default */
 function lumetriReset(trackIndex, clipIndex) {
     try {
         if (!app.project) return _err("No project is open");
@@ -5051,7 +5051,7 @@ function lumetriReset(trackIndex, clipIndex) {
     } catch (e) { return _err("lumetriReset failed: " + e.message); }
 }
 
-/** 26. getColorInfo — Get basic color statistics for a clip */
+/** 26. getColorInfo - Get basic color statistics for a clip */
 function getColorInfo(trackIndex, clipIndex) {
     try {
         if (!app.project) return _err("No project is open");
@@ -5078,7 +5078,7 @@ function getColorInfo(trackIndex, clipIndex) {
 /** Internal variable to store copied Lumetri settings for paste operations */
 var _copiedLumetriSettings = null;
 
-/** 27. copyColorGrade — Copy Lumetri settings from a source clip */
+/** 27. copyColorGrade - Copy Lumetri settings from a source clip */
 function copyColorGrade(srcTrackIndex, srcClipIndex) {
     try {
         if (!app.project) return _err("No project is open");
@@ -5090,7 +5090,7 @@ function copyColorGrade(srcTrackIndex, srcClipIndex) {
     } catch (e) { return _err("copyColorGrade failed: " + e.message); }
 }
 
-/** 28. pasteColorGrade — Paste previously copied Lumetri settings */
+/** 28. pasteColorGrade - Paste previously copied Lumetri settings */
 function pasteColorGrade(destTrackIndex, destClipIndex) {
     try {
         if (!app.project) return _err("No project is open");
@@ -5103,7 +5103,7 @@ function pasteColorGrade(destTrackIndex, destClipIndex) {
     } catch (e) { return _err("pasteColorGrade failed: " + e.message); }
 }
 
-/** 29. applyColorGradeToAll — Apply grade from source clip to all clips on a track */
+/** 29. applyColorGradeToAll - Apply grade from source clip to all clips on a track */
 function applyColorGradeToAll(srcTrackIndex, srcClipIndex, trackIndex) {
     try {
         if (!app.project) return _err("No project is open");
@@ -5124,7 +5124,7 @@ function applyColorGradeToAll(srcTrackIndex, srcClipIndex, trackIndex) {
     } catch (e) { return _err("applyColorGradeToAll failed: " + e.message); }
 }
 
-/** 30. lumetriAutoWhiteBalance — Auto white balance (resets temperature and tint to neutral) */
+/** 30. lumetriAutoWhiteBalance - Auto white balance (resets temperature and tint to neutral) */
 function lumetriAutoWhiteBalance(trackIndex, clipIndex) {
     try {
         if (!app.project) return _err("No project is open");
@@ -9758,7 +9758,7 @@ function extractAudioFromVideo(projectItemIndex) {
 // ---------------------------------------------------------------------------
 
 /**
- * 1. getGeneralPreferences — Get general preferences.
+ * 1. getGeneralPreferences - Get general preferences.
  */
 function getGeneralPreferences() {
     try {
@@ -9783,7 +9783,7 @@ function getGeneralPreferences() {
 }
 
 /**
- * 2. setDefaultStillDuration — Set default still image duration in frames.
+ * 2. setDefaultStillDuration - Set default still image duration in frames.
  */
 function setDefaultStillDuration(frames) {
     try {
@@ -9801,7 +9801,7 @@ function setDefaultStillDuration(frames) {
 }
 
 /**
- * 3. setDefaultTransitionDuration — Set default video transition duration in seconds.
+ * 3. setDefaultTransitionDuration - Set default video transition duration in seconds.
  */
 function setDefaultTransitionDuration(seconds) {
     try {
@@ -9818,7 +9818,7 @@ function setDefaultTransitionDuration(seconds) {
 }
 
 /**
- * 4. setDefaultAudioTransitionDuration — Set default audio transition duration in seconds.
+ * 4. setDefaultAudioTransitionDuration - Set default audio transition duration in seconds.
  */
 function setDefaultAudioTransitionDuration(seconds) {
     try {
@@ -9839,7 +9839,7 @@ function setDefaultAudioTransitionDuration(seconds) {
 // ---------------------------------------------------------------------------
 
 /**
- * 5. getBrightness — Get UI brightness level.
+ * 5. getBrightness - Get UI brightness level.
  */
 function getBrightness() {
     try {
@@ -9852,7 +9852,7 @@ function getBrightness() {
 }
 
 /**
- * 6. setBrightness — Set UI brightness (0-255).
+ * 6. setBrightness - Set UI brightness (0-255).
  */
 function setBrightness(level) {
     try {
@@ -9876,7 +9876,7 @@ function setBrightness(level) {
 // ---------------------------------------------------------------------------
 
 /**
- * 7. setAutoSaveEnabled — Enable/disable auto-save.
+ * 7. setAutoSaveEnabled - Enable/disable auto-save.
  */
 function setAutoSaveEnabled(enabled) {
     try {
@@ -9891,7 +9891,7 @@ function setAutoSaveEnabled(enabled) {
 }
 
 /**
- * 8. setAutoSaveMaxVersions — Set max auto-save versions.
+ * 8. setAutoSaveMaxVersions - Set max auto-save versions.
  */
 function setAutoSaveMaxVersions(count) {
     try {
@@ -9909,7 +9909,7 @@ function setAutoSaveMaxVersions(count) {
 }
 
 /**
- * 9. getAutoSaveLocation — Get auto-save folder location.
+ * 9. getAutoSaveLocation - Get auto-save folder location.
  */
 function getAutoSaveLocation() {
     try {
@@ -9933,7 +9933,7 @@ function getAutoSaveLocation() {
 // ---------------------------------------------------------------------------
 
 /**
- * 10. getPlaybackResolution — Get playback resolution setting.
+ * 10. getPlaybackResolution - Get playback resolution setting.
  */
 function getPlaybackResolution() {
     try {
@@ -9951,7 +9951,7 @@ function getPlaybackResolution() {
 }
 
 /**
- * 11. setPlaybackResolution — Set playback resolution (full, 1/2, 1/4, 1/8, 1/16).
+ * 11. setPlaybackResolution - Set playback resolution (full, 1/2, 1/4, 1/8, 1/16).
  */
 function setPlaybackResolution(quality) {
     try {
@@ -9978,7 +9978,7 @@ function setPlaybackResolution(quality) {
 }
 
 /**
- * 12. getPrerollFrames — Get pre-roll frames.
+ * 12. getPrerollFrames - Get pre-roll frames.
  */
 function getPrerollFrames() {
     try {
@@ -9991,7 +9991,7 @@ function getPrerollFrames() {
 }
 
 /**
- * 13. setPrerollFrames — Set pre-roll frames.
+ * 13. setPrerollFrames - Set pre-roll frames.
  */
 function setPrerollFrames(frames) {
     try {
@@ -10009,7 +10009,7 @@ function setPrerollFrames(frames) {
 }
 
 /**
- * 14. getPostrollFrames — Get post-roll frames.
+ * 14. getPostrollFrames - Get post-roll frames.
  */
 function getPostrollFrames() {
     try {
@@ -10022,7 +10022,7 @@ function getPostrollFrames() {
 }
 
 /**
- * 15. setPostrollFrames — Set post-roll frames.
+ * 15. setPostrollFrames - Set post-roll frames.
  */
 function setPostrollFrames(frames) {
     try {
@@ -10044,7 +10044,7 @@ function setPostrollFrames(frames) {
 // ---------------------------------------------------------------------------
 
 /**
- * 16. getTimelineSettings — Get all timeline preferences.
+ * 16. getTimelineSettings - Get all timeline preferences.
  */
 function getTimelineSettings() {
     try {
@@ -10066,7 +10066,7 @@ function getTimelineSettings() {
 }
 
 /**
- * 17. setTimeDisplayFormat — Set time display format (timecode, frames, feet+frames).
+ * 17. setTimeDisplayFormat - Set time display format (timecode, frames, feet+frames).
  */
 function setTimeDisplayFormat(format) {
     try {
@@ -10083,7 +10083,7 @@ function setTimeDisplayFormat(format) {
 }
 
 /**
- * 18. setVideoTransitionDefaultDuration — Set default video transition duration in frames.
+ * 18. setVideoTransitionDefaultDuration - Set default video transition duration in frames.
  */
 function setVideoTransitionDefaultDuration(frames) {
     try {
@@ -10105,7 +10105,7 @@ function setVideoTransitionDefaultDuration(frames) {
 // ---------------------------------------------------------------------------
 
 /**
- * 19. getMediaCacheSettings — Get media cache settings.
+ * 19. getMediaCacheSettings - Get media cache settings.
  */
 function getMediaCacheSettings() {
     try {
@@ -10123,7 +10123,7 @@ function getMediaCacheSettings() {
 }
 
 /**
- * 20. setMediaCacheLocation — Set media cache location.
+ * 20. setMediaCacheLocation - Set media cache location.
  */
 function setMediaCacheLocation(path) {
     try {
@@ -10144,7 +10144,7 @@ function setMediaCacheLocation(path) {
 }
 
 /**
- * 21. setMediaCacheSize — Set max media cache size in GB.
+ * 21. setMediaCacheSize - Set max media cache size in GB.
  */
 function setMediaCacheSize(maxGB) {
     try {
@@ -10161,7 +10161,7 @@ function setMediaCacheSize(maxGB) {
 }
 
 /**
- * 22. cleanMediaCacheOlderThan — Clean cache files older than N days.
+ * 22. cleanMediaCacheOlderThan - Clean cache files older than N days.
  */
 function cleanMediaCacheOlderThan(days) {
     try {
@@ -10198,7 +10198,7 @@ function cleanMediaCacheOlderThan(days) {
 // ---------------------------------------------------------------------------
 
 /**
- * 23. getLabelColorNames — Get all label color names.
+ * 23. getLabelColorNames - Get all label color names.
  */
 function getLabelColorNames() {
     try {
@@ -10224,7 +10224,7 @@ function getLabelColorNames() {
 }
 
 /**
- * 24. setLabelColorName — Rename a label color.
+ * 24. setLabelColorName - Rename a label color.
  */
 function setLabelColorName(index, name) {
     try {
@@ -10249,7 +10249,7 @@ function setLabelColorName(index, name) {
 // ---------------------------------------------------------------------------
 
 /**
- * 25. getRendererInfo — Get current renderer (Software, CUDA, Metal, OpenCL).
+ * 25. getRendererInfo - Get current renderer (Software, CUDA, Metal, OpenCL).
  */
 function getRendererInfo() {
     try {
@@ -10272,7 +10272,7 @@ function getRendererInfo() {
 }
 
 /**
- * 26. getGPUInfo — Get GPU information.
+ * 26. getGPUInfo - Get GPU information.
  */
 function getGPUInfo() {
     try {
@@ -10299,7 +10299,7 @@ function getGPUInfo() {
 }
 
 /**
- * 27. setRenderer — Set the active renderer.
+ * 27. setRenderer - Set the active renderer.
  */
 function setRenderer(rendererName) {
     try {
@@ -10320,7 +10320,7 @@ function setRenderer(rendererName) {
 // ---------------------------------------------------------------------------
 
 /**
- * 28. getDefaultSequencePresets — List available sequence presets.
+ * 28. getDefaultSequencePresets - List available sequence presets.
  */
 function getDefaultSequencePresets() {
     try {
@@ -10347,7 +10347,7 @@ function getDefaultSequencePresets() {
 }
 
 /**
- * 29. setDefaultSequencePreset — Set default sequence preset.
+ * 29. setDefaultSequencePreset - Set default sequence preset.
  */
 function setDefaultSequencePreset(presetPath) {
     try {
@@ -10368,7 +10368,7 @@ function setDefaultSequencePreset(presetPath) {
 }
 
 /**
- * 30. getInstalledCodecs — List installed codecs/formats.
+ * 30. getInstalledCodecs - List installed codecs/formats.
  */
 function getInstalledCodecs() {
     try {
@@ -12801,7 +12801,7 @@ function playMacro(name) {
 
 // ===========================================================================
 // VR / 360 Video, HDR, Stereoscopic, Frame Rate, Aspect Ratio, Timecode,
-// Render Settings, and Closed Captions (Extended) — Immersive & Advanced
+// Render Settings, and Closed Captions (Extended) - Immersive & Advanced
 // ===========================================================================
 
 // ---------------------------------------------------------------------------
@@ -14818,7 +14818,7 @@ function optimizeProject() {
 // ---------------------------------------------------------------------------
 
 /**
- * createMontage — Auto-assemble clips with transitions and background music.
+ * createMontage - Auto-assemble clips with transitions and background music.
  * @param {string} clipIndicesJSON - JSON array of project item indices
  * @param {string} transitionName - Transition to apply between clips
  * @param {number} transitionDuration - Transition duration in seconds
@@ -14878,7 +14878,7 @@ function createMontage(clipIndicesJSON, transitionName, transitionDuration, musi
 }
 
 /**
- * createSlideshow — Create a slideshow from images with transitions and music.
+ * createSlideshow - Create a slideshow from images with transitions and music.
  * @param {string} imageIndicesJSON - JSON array of project item indices for images
  * @param {number} slideDuration - Duration per slide in seconds
  * @param {string} transitionName - Transition between slides
@@ -14928,7 +14928,7 @@ function createSlideshow(imageIndicesJSON, slideDuration, transitionName, musicP
 }
 
 /**
- * createHighlightReel — Extract marker-tagged sections into a new highlight sequence.
+ * createHighlightReel - Extract marker-tagged sections into a new highlight sequence.
  * @param {number} sequenceIndex - Index of the source sequence
  * @param {string} markerColor - Marker color to filter (e.g. "Green")
  * @param {string} outputName - Name for the highlight sequence
@@ -14982,7 +14982,7 @@ function createHighlightReel(sequenceIndex, markerColor, outputName) {
 }
 
 /**
- * rippleDeleteEmptySpaces — Remove all empty spaces (gaps) across all tracks.
+ * rippleDeleteEmptySpaces - Remove all empty spaces (gaps) across all tracks.
  */
 function rippleDeleteEmptySpaces() {
     try {
@@ -15026,7 +15026,7 @@ function rippleDeleteEmptySpaces() {
 }
 
 /**
- * alignAllClipsToTrack — Move clips from one track to align with clips on another.
+ * alignAllClipsToTrack - Move clips from one track to align with clips on another.
  * @param {number} sourceTrack - Source video track index
  * @param {number} destTrack - Destination video track index
  */
@@ -15060,7 +15060,7 @@ function alignAllClipsToTrack(sourceTrack, destTrack) {
 // ---------------------------------------------------------------------------
 
 /**
- * syncAllAudioToVideo — Attempt to sync audio clips to corresponding video by timecode.
+ * syncAllAudioToVideo - Attempt to sync audio clips to corresponding video by timecode.
  */
 function syncAllAudioToVideo() {
     try {
@@ -15098,7 +15098,7 @@ function syncAllAudioToVideo() {
 }
 
 /**
- * replaceAudio — Replace the audio of a video clip at given track/clip index.
+ * replaceAudio - Replace the audio of a video clip at given track/clip index.
  * @param {number} videoTrackIndex - Video track index
  * @param {number} videoClipIndex - Clip index on the video track
  * @param {string} audioPath - Path to the replacement audio file
@@ -15130,7 +15130,7 @@ function replaceAudio(videoTrackIndex, videoClipIndex, audioPath) {
 }
 
 /**
- * addMusicBed — Add background music with fades and volume control.
+ * addMusicBed - Add background music with fades and volume control.
  * @param {string} audioPath - Path to the music file
  * @param {number} trackIndex - Audio track index
  * @param {number} startTime - Start time in seconds
@@ -15170,7 +15170,7 @@ function addMusicBed(audioPath, trackIndex, startTime, endTime, fadeIn, fadeOut,
 }
 
 /**
- * duckMusicUnderDialogue — Lower music volume under dialogue clips.
+ * duckMusicUnderDialogue - Lower music volume under dialogue clips.
  * @param {number} musicTrackIndex - Audio track index of music
  * @param {number} dialogueTrackIndex - Audio track index of dialogue
  * @param {number} duckAmount - Amount to duck in dB (positive number, e.g. 12)
@@ -15212,7 +15212,7 @@ function duckMusicUnderDialogue(musicTrackIndex, dialogueTrackIndex, duckAmount)
 }
 
 /**
- * addSoundEffect — Place a sound effect at a specific time on a track.
+ * addSoundEffect - Place a sound effect at a specific time on a track.
  * @param {string} sfxPath - Path to the sound effect file
  * @param {number} trackIndex - Audio track index
  * @param {number} time - Time in seconds to place the SFX
@@ -15240,7 +15240,7 @@ function addSoundEffect(sfxPath, trackIndex, time, volume) {
 // ---------------------------------------------------------------------------
 
 /**
- * matchColorBetweenClips — Copy Lumetri color settings from one clip to another.
+ * matchColorBetweenClips - Copy Lumetri color settings from one clip to another.
  * @param {number} srcTrackIndex - Source video track index
  * @param {number} srcClipIndex - Source clip index
  * @param {number} destTrackIndex - Destination video track index
@@ -15279,7 +15279,7 @@ function matchColorBetweenClips(srcTrackIndex, srcClipIndex, destTrackIndex, des
 }
 
 /**
- * applyColorPreset — Apply a named color preset to a clip.
+ * applyColorPreset - Apply a named color preset to a clip.
  * @param {number} trackIndex - Video track index
  * @param {number} clipIndex - Clip index
  * @param {string} presetName - Preset name (Warm, Cool, Vintage, Cinematic, Desaturated, HighContrast)
@@ -15311,7 +15311,7 @@ function applyColorPreset(trackIndex, clipIndex, presetName) {
 }
 
 /**
- * createColorGradient — Apply gradual color temperature change across clips.
+ * createColorGradient - Apply gradual color temperature change across clips.
  * @param {number} trackIndex - Video track index
  * @param {number} startClipIndex - First clip index
  * @param {number} endClipIndex - Last clip index
@@ -15352,7 +15352,7 @@ function createColorGradient(trackIndex, startClipIndex, endClipIndex, startTemp
 }
 
 /**
- * autoCorrectAllClips — Auto color correct all clips on a video track.
+ * autoCorrectAllClips - Auto color correct all clips on a video track.
  * @param {number} trackIndex - Video track index
  */
 function autoCorrectAllClips(trackIndex) {
@@ -15383,7 +15383,7 @@ function autoCorrectAllClips(trackIndex) {
 // ---------------------------------------------------------------------------
 
 /**
- * addSubtitlesFromSRT — Parse an SRT file and place subtitles on the timeline.
+ * addSubtitlesFromSRT - Parse an SRT file and place subtitles on the timeline.
  * @param {string} srtPath - Path to the SRT file
  * @param {number} trackIndex - Video track index for captions
  */
@@ -15424,7 +15424,7 @@ function addSubtitlesFromSRT(srtPath, trackIndex) {
 }
 
 /**
- * addEndCredits — Add scrolling end credits to the timeline.
+ * addEndCredits - Add scrolling end credits to the timeline.
  * @param {string} creditsJSON - JSON array of credit lines [{role, name}]
  * @param {number} trackIndex - Video track index
  * @param {number} scrollDuration - Duration of the credits scroll in seconds
@@ -15455,7 +15455,7 @@ function addEndCredits(creditsJSON, trackIndex, scrollDuration, style) {
 }
 
 /**
- * addChapterMarkers — Add chapter markers to the active sequence.
+ * addChapterMarkers - Add chapter markers to the active sequence.
  * @param {string} chaptersJSON - JSON array of [{time, title}]
  */
 function addChapterMarkers(chaptersJSON) {
@@ -15481,7 +15481,7 @@ function addChapterMarkers(chaptersJSON) {
 }
 
 /**
- * generateChaptersFromMarkers — Export markers as YouTube chapter format.
+ * generateChaptersFromMarkers - Export markers as YouTube chapter format.
  * @param {string} outputPath - File path to write the chapters text
  */
 function generateChaptersFromMarkers(outputPath) {
@@ -15530,7 +15530,7 @@ function generateChaptersFromMarkers(outputPath) {
 // ---------------------------------------------------------------------------
 
 /**
- * exportForYouTube — Export with YouTube-optimized settings (H.264, 1080p or 4K).
+ * exportForYouTube - Export with YouTube-optimized settings (H.264, 1080p or 4K).
  * @param {string} outputPath - Output file path
  * @param {string} title - Video title metadata
  * @param {string} description - Video description metadata
@@ -15566,7 +15566,7 @@ function exportForYouTube(outputPath, title, description) {
 }
 
 /**
- * exportForInstagram — Export for Instagram with specific aspect ratio.
+ * exportForInstagram - Export for Instagram with specific aspect ratio.
  * @param {string} outputPath - Output file path
  * @param {string} aspectRatio - "1:1", "4:5", or "9:16"
  */
@@ -15591,7 +15591,7 @@ function exportForInstagram(outputPath, aspectRatio) {
 }
 
 /**
- * exportForTikTok — Export for TikTok (9:16, <3 minutes, H.264).
+ * exportForTikTok - Export for TikTok (9:16, <3 minutes, H.264).
  * @param {string} outputPath - Output file path
  */
 function exportForTikTok(outputPath) {
@@ -15614,7 +15614,7 @@ function exportForTikTok(outputPath) {
 }
 
 /**
- * exportForTwitter — Export for Twitter (16:9, <2:20, H.264).
+ * exportForTwitter - Export for Twitter (16:9, <2:20, H.264).
  * @param {string} outputPath - Output file path
  */
 function exportForTwitter(outputPath) {
@@ -15638,7 +15638,7 @@ function exportForTwitter(outputPath) {
 }
 
 /**
- * exportMultipleFormats — Export in multiple formats at once.
+ * exportMultipleFormats - Export in multiple formats at once.
  * @param {string} outputDir - Output directory path
  * @param {string} formatsJSON - JSON array of format strings: ["youtube","instagram_square","tiktok","twitter"]
  */
@@ -15673,7 +15673,7 @@ function exportMultipleFormats(outputDir, formatsJSON) {
 // ---------------------------------------------------------------------------
 
 /**
- * setupNewProject — Full project setup with configuration.
+ * setupNewProject - Full project setup with configuration.
  * @param {string} name - Project name
  * @param {string} path - Project file path
  * @param {string} resolution - "1080p" or "4k"
@@ -15701,7 +15701,7 @@ function setupNewProject(name, path, resolution, fps, audioSampleRate) {
 }
 
 /**
- * setupEditingWorkspace — Complete workspace setup.
+ * setupEditingWorkspace - Complete workspace setup.
  * @param {string} projectPath - Project file path to open
  * @param {string} mediaFolder - Path to media folder to import
  * @param {string} sequenceName - Name for the initial sequence
@@ -15729,7 +15729,7 @@ function setupEditingWorkspace(projectPath, mediaFolder, sequenceName) {
 }
 
 /**
- * importAndOrganize — Import all media from a folder and auto-organize into bins.
+ * importAndOrganize - Import all media from a folder and auto-organize into bins.
  * @param {string} mediaFolder - Path to the media folder
  * @param {boolean} autoCreateBins - Whether to auto-create bins by type
  */
@@ -15774,7 +15774,7 @@ function importAndOrganize(mediaFolder, autoCreateBins) {
 }
 
 /**
- * prepareForDelivery — Check specs and prepare project for final delivery.
+ * prepareForDelivery - Check specs and prepare project for final delivery.
  * @param {string} specsJSON - JSON object with delivery specs {width, height, fps, audioDB, maxDuration}
  */
 function prepareForDelivery(specsJSON) {
@@ -15823,7 +15823,7 @@ function prepareForDelivery(specsJSON) {
 // ---------------------------------------------------------------------------
 
 /**
- * archiveProject — Archive the current project with optional media.
+ * archiveProject - Archive the current project with optional media.
  * @param {string} outputPath - Archive output path
  * @param {boolean} includeMedia - Include media files
  * @param {boolean} includeRenders - Include rendered files
@@ -15850,7 +15850,7 @@ function archiveProject(outputPath, includeMedia, includeRenders) {
 }
 
 /**
- * trimProject — Remove unused media and clean the project.
+ * trimProject - Remove unused media and clean the project.
  */
 function trimProject() {
     try {
@@ -15890,7 +15890,7 @@ function trimProject() {
 }
 
 /**
- * consolidateAndTranscode — Consolidate media and transcode to a single codec.
+ * consolidateAndTranscode - Consolidate media and transcode to a single codec.
  * @param {string} outputDir - Output directory for consolidated media
  * @param {string} codec - Target codec (e.g. "h264", "prores")
  * @param {string} quality - Quality preset ("low", "medium", "high")
@@ -16757,7 +16757,7 @@ function showDialog(title, message, buttons) {
 // ---------------------------------------------------------------------------
 
 /**
- * openPanel — Open a Premiere Pro panel by name.
+ * openPanel - Open a Premiere Pro panel by name.
  */
 function openPanel(panelName) {
     try {
@@ -16788,7 +16788,7 @@ function openPanel(panelName) {
 }
 
 /**
- * closePanel — Close a Premiere Pro panel by name.
+ * closePanel - Close a Premiere Pro panel by name.
  */
 function closePanel(panelName) {
     try {
@@ -16804,7 +16804,7 @@ function closePanel(panelName) {
 }
 
 /**
- * getOpenPanels — List currently open panels.
+ * getOpenPanels - List currently open panels.
  */
 function getOpenPanels() {
     try {
@@ -16828,7 +16828,7 @@ function getOpenPanels() {
 }
 
 /**
- * resetPanelLayout — Reset to default panel layout.
+ * resetPanelLayout - Reset to default panel layout.
  */
 function resetPanelLayout() {
     try {
@@ -16841,7 +16841,7 @@ function resetPanelLayout() {
 }
 
 /**
- * maximizePanel — Maximize a panel (full screen toggle).
+ * maximizePanel - Maximize a panel (full screen toggle).
  */
 function maximizePanel(panelName) {
     try {
@@ -16861,7 +16861,7 @@ function maximizePanel(panelName) {
 // ---------------------------------------------------------------------------
 
 /**
- * getWindowInfo — Get main window size and position.
+ * getWindowInfo - Get main window size and position.
  */
 function getWindowInfo() {
     try {
@@ -16893,7 +16893,7 @@ function getWindowInfo() {
 }
 
 /**
- * setWindowSize — Set main window size.
+ * setWindowSize - Set main window size.
  */
 function setWindowSize(width, height) {
     try {
@@ -16911,7 +16911,7 @@ function setWindowSize(width, height) {
 }
 
 /**
- * minimizeWindow — Minimize Premiere Pro.
+ * minimizeWindow - Minimize Premiere Pro.
  */
 function minimizeWindow() {
     try {
@@ -16923,7 +16923,7 @@ function minimizeWindow() {
 }
 
 /**
- * bringToFront — Bring Premiere Pro window to front.
+ * bringToFront - Bring Premiere Pro window to front.
  */
 function bringToFront() {
     try {
@@ -16936,7 +16936,7 @@ function bringToFront() {
 }
 
 /**
- * enterFullscreen — Enter fullscreen mode.
+ * enterFullscreen - Enter fullscreen mode.
  */
 function enterFullscreen() {
     try {
@@ -16953,7 +16953,7 @@ function enterFullscreen() {
 // ---------------------------------------------------------------------------
 
 /**
- * setTrackHeight — Set individual track height.
+ * setTrackHeight - Set individual track height.
  */
 function setTrackHeight(trackType, trackIndex, height) {
     try {
@@ -16980,7 +16980,7 @@ function setTrackHeight(trackType, trackIndex, height) {
 }
 
 /**
- * collapseTrack — Collapse a track.
+ * collapseTrack - Collapse a track.
  */
 function collapseTrack(trackType, trackIndex) {
     try {
@@ -17005,7 +17005,7 @@ function collapseTrack(trackType, trackIndex) {
 }
 
 /**
- * expandTrack — Expand a track.
+ * expandTrack - Expand a track.
  */
 function expandTrack(trackType, trackIndex) {
     try {
@@ -17031,7 +17031,7 @@ function expandTrack(trackType, trackIndex) {
 }
 
 /**
- * collapseAllTracks — Collapse all tracks.
+ * collapseAllTracks - Collapse all tracks.
  */
 function collapseAllTracks() {
     try {
@@ -17055,7 +17055,7 @@ function collapseAllTracks() {
 }
 
 /**
- * expandAllTracks — Expand all tracks.
+ * expandAllTracks - Expand all tracks.
  */
 function expandAllTracks() {
     try {
@@ -17084,7 +17084,7 @@ function expandAllTracks() {
 // ---------------------------------------------------------------------------
 
 /**
- * setLabelPreferences — Set all label color names.
+ * setLabelPreferences - Set all label color names.
  */
 function setLabelPreferences(labels) {
     try {
@@ -17112,7 +17112,7 @@ function setLabelPreferences(labels) {
 }
 
 /**
- * getActiveLabelFilter — Get active label filter in project panel.
+ * getActiveLabelFilter - Get active label filter in project panel.
  */
 function getActiveLabelFilter() {
     try {
@@ -17131,7 +17131,7 @@ function getActiveLabelFilter() {
 }
 
 /**
- * setLabelFilter — Filter project panel by label color.
+ * setLabelFilter - Filter project panel by label color.
  */
 function setLabelFilter(colorIndex) {
     try {
@@ -17147,7 +17147,7 @@ function setLabelFilter(colorIndex) {
 }
 
 /**
- * clearLabelFilter — Clear label filter.
+ * clearLabelFilter - Clear label filter.
  */
 function clearLabelFilter() {
     try {
@@ -17164,7 +17164,7 @@ function clearLabelFilter() {
 // Note: setTimeDisplayFormat (item 20) already exists above in the preferences section.
 
 /**
- * setAudioWaveformDisplay — Show/hide audio waveforms on timeline.
+ * setAudioWaveformDisplay - Show/hide audio waveforms on timeline.
  */
 function setAudioWaveformDisplay(enabled) {
     try {
@@ -17180,7 +17180,7 @@ function setAudioWaveformDisplay(enabled) {
 }
 
 /**
- * setVideoThumbnailDisplay — Show/hide video thumbnails on timeline.
+ * setVideoThumbnailDisplay - Show/hide video thumbnails on timeline.
  */
 function setVideoThumbnailDisplay(enabled) {
     try {
@@ -17196,7 +17196,7 @@ function setVideoThumbnailDisplay(enabled) {
 }
 
 /**
- * setTrackNameDisplay — Show/hide track names.
+ * setTrackNameDisplay - Show/hide track names.
  */
 function setTrackNameDisplay(enabled) {
     try {
@@ -17216,7 +17216,7 @@ function setTrackNameDisplay(enabled) {
 // ---------------------------------------------------------------------------
 
 /**
- * showAlert — Show alert dialog.
+ * showAlert - Show alert dialog.
  */
 function showAlert(title, message) {
     try {
@@ -17228,7 +17228,7 @@ function showAlert(title, message) {
 }
 
 /**
- * showConfirmDialog — Show confirm dialog (yes/no).
+ * showConfirmDialog - Show confirm dialog (yes/no).
  */
 function showConfirmDialog(title, message) {
     try {
@@ -17240,7 +17240,7 @@ function showConfirmDialog(title, message) {
 }
 
 /**
- * showInputDialog — Show input dialog.
+ * showInputDialog - Show input dialog.
  */
 function showInputDialog(title, promptText, defaultValue) {
     try {
@@ -17256,7 +17256,7 @@ function showInputDialog(title, promptText, defaultValue) {
 }
 
 /**
- * showProgressDialog — Show progress dialog.
+ * showProgressDialog - Show progress dialog.
  */
 function showProgressDialog(title, message, progress) {
     try {
@@ -17281,7 +17281,7 @@ function showProgressDialog(title, message, progress) {
 }
 
 /**
- * writeToConsole — Write to ExtendScript console.
+ * writeToConsole - Write to ExtendScript console.
  */
 function writeToConsole(message) {
     try {
@@ -17296,7 +17296,7 @@ function writeToConsole(message) {
 // ---------------------------------------------------------------------------
 
 /**
- * getUIScaling — Get current UI scaling factor.
+ * getUIScaling - Get current UI scaling factor.
  */
 function getUIScaling() {
     try {
@@ -17326,7 +17326,7 @@ function getUIScaling() {
 }
 
 /**
- * setHighContrastMode — Toggle high contrast mode.
+ * setHighContrastMode - Toggle high contrast mode.
  */
 function setHighContrastMode(enabled) {
     try {
@@ -17350,7 +17350,7 @@ function setHighContrastMode(enabled) {
 // ============================================================================
 
 /**
- * assembleFromEDL — Assemble timeline from EDL JSON.
+ * assembleFromEDL - Assemble timeline from EDL JSON.
  * edlJson: JSON string with {clips:[{file,inPoint,outPoint,trackIndex,position,transitionName,transitionDuration},...]}
  */
 function assembleFromEDL(edlJson) {
@@ -17400,7 +17400,7 @@ function assembleFromEDL(edlJson) {
 }
 
 /**
- * assembleFromCSV — Assemble timeline from CSV file.
+ * assembleFromCSV - Assemble timeline from CSV file.
  * Columns: file, in, out, track, position
  */
 function assembleFromCSV(csvPath) {
@@ -17443,7 +17443,7 @@ function assembleFromCSV(csvPath) {
 }
 
 /**
- * assembleFromFolderOrder — Assemble clips from folder in filename order.
+ * assembleFromFolderOrder - Assemble clips from folder in filename order.
  */
 function assembleFromFolderOrder(folderPath, transitionName, transitionDuration) {
     try {
@@ -17482,7 +17482,7 @@ function assembleFromFolderOrder(folderPath, transitionName, transitionDuration)
 }
 
 /**
- * interleaveClips — Interleave clips from two tracks onto a destination arrangement.
+ * interleaveClips - Interleave clips from two tracks onto a destination arrangement.
  */
 function interleaveClips(trackIndexA, trackIndexB, transitionDuration) {
     try {
@@ -17514,7 +17514,7 @@ function interleaveClips(trackIndexA, trackIndexB, transitionDuration) {
 }
 
 /**
- * shuffleClips — Randomly shuffle clip order on a track.
+ * shuffleClips - Randomly shuffle clip order on a track.
  */
 function shuffleClips(trackType, trackIndex) {
     try {
@@ -17540,7 +17540,7 @@ function shuffleClips(trackType, trackIndex) {
 }
 
 /**
- * sortClipsByDuration — Sort clips by duration on a track.
+ * sortClipsByDuration - Sort clips by duration on a track.
  */
 function sortClipsByDuration(trackType, trackIndex, ascending) {
     try {
@@ -17563,7 +17563,7 @@ function sortClipsByDuration(trackType, trackIndex, ascending) {
 }
 
 /**
- * sortClipsByName — Sort clips alphabetically by clip name.
+ * sortClipsByName - Sort clips alphabetically by clip name.
  */
 function sortClipsByName(trackType, trackIndex, ascending) {
     try {
@@ -17591,7 +17591,7 @@ function sortClipsByName(trackType, trackIndex, ascending) {
 }
 
 /**
- * sortClipsByFileName — Sort clips by source file name.
+ * sortClipsByFileName - Sort clips by source file name.
  */
 function sortClipsByFileName(trackType, trackIndex, ascending) {
     try {
@@ -17623,7 +17623,7 @@ function sortClipsByFileName(trackType, trackIndex, ascending) {
 }
 
 /**
- * reverseClipOrder — Reverse order of clips on a track.
+ * reverseClipOrder - Reverse order of clips on a track.
  */
 function reverseClipOrder(trackType, trackIndex) {
     try {
@@ -17645,7 +17645,7 @@ function reverseClipOrder(trackType, trackIndex) {
 }
 
 /**
- * distributeClipsEvenly — Distribute clips evenly over a total duration.
+ * distributeClipsEvenly - Distribute clips evenly over a total duration.
  */
 function distributeClipsEvenly(trackType, trackIndex, totalDuration) {
     try {
@@ -17677,7 +17677,7 @@ function distributeClipsEvenly(trackType, trackIndex, totalDuration) {
 }
 
 /**
- * stackClips — Remove gaps, stack all clips from a start time.
+ * stackClips - Remove gaps, stack all clips from a start time.
  */
 function stackClips(trackType, trackIndex, startTime) {
     try {
@@ -17705,7 +17705,7 @@ function stackClips(trackType, trackIndex, startTime) {
 }
 
 /**
- * createOverlayTrack — Create overlay from one track over another with opacity and blend mode.
+ * createOverlayTrack - Create overlay from one track over another with opacity and blend mode.
  */
 function createOverlayTrack(sourceTrack, destTrack, opacity, blendMode) {
     try {
@@ -17731,7 +17731,7 @@ function createOverlayTrack(sourceTrack, destTrack, opacity, blendMode) {
 }
 
 /**
- * createGreenScreenComposite — Chroma key composite of foreground over background.
+ * createGreenScreenComposite - Chroma key composite of foreground over background.
  */
 function createGreenScreenComposite(fgTrackIndex, fgClipIndex, bgTrackIndex, bgClipIndex, keyColor) {
     try {
@@ -17756,7 +17756,7 @@ function createGreenScreenComposite(fgTrackIndex, fgClipIndex, bgTrackIndex, bgC
 }
 
 /**
- * createPictureInPictureGrid — Multi-source PIP grid layout.
+ * createPictureInPictureGrid - Multi-source PIP grid layout.
  */
 function createPictureInPictureGrid(trackIndicesJSON, layout) {
     try {
@@ -17782,7 +17782,7 @@ function createPictureInPictureGrid(trackIndicesJSON, layout) {
 }
 
 /**
- * layerTracks — Layer multiple tracks with specified opacities.
+ * layerTracks - Layer multiple tracks with specified opacities.
  */
 function layerTracks(baseTrack, overlayTracksJSON, opacitiesJSON) {
     try {
@@ -17807,7 +17807,7 @@ function layerTracks(baseTrack, overlayTracksJSON, opacitiesJSON) {
 }
 
 /**
- * generateBlackClip — Generate a black video clip on the timeline.
+ * generateBlackClip - Generate a black video clip on the timeline.
  */
 function generateBlackClip(trackIndex, startTime, duration) {
     try {
@@ -17827,7 +17827,7 @@ function generateBlackClip(trackIndex, startTime, duration) {
 }
 
 /**
- * generateColorClip — Generate a solid color clip on the timeline.
+ * generateColorClip - Generate a solid color clip on the timeline.
  * color: hex string e.g. "#FF0000"
  */
 function generateColorClip(trackIndex, startTime, duration, color) {
@@ -17850,7 +17850,7 @@ function generateColorClip(trackIndex, startTime, duration, color) {
 }
 
 /**
- * generateGradientClip — Generate a gradient clip on the timeline.
+ * generateGradientClip - Generate a gradient clip on the timeline.
  */
 function generateGradientClip(trackIndex, startTime, duration, colorStart, colorEnd, direction) {
     try {
@@ -17869,7 +17869,7 @@ function generateGradientClip(trackIndex, startTime, duration, colorStart, color
 }
 
 /**
- * generateTestPattern — Generate a test pattern clip (bars, grid, checkerboard).
+ * generateTestPattern - Generate a test pattern clip (bars, grid, checkerboard).
  */
 function generateTestPattern(trackIndex, startTime, duration, pattern) {
     try {
@@ -17893,7 +17893,7 @@ function generateTestPattern(trackIndex, startTime, duration, pattern) {
 }
 
 /**
- * generateSilence — Generate a silent audio clip.
+ * generateSilence - Generate a silent audio clip.
  */
 function generateSilence(trackIndex, startTime, duration) {
     try {
@@ -17909,7 +17909,7 @@ function generateSilence(trackIndex, startTime, duration) {
 }
 
 /**
- * generateTone — Generate an audio tone (sine, square, sawtooth).
+ * generateTone - Generate an audio tone (sine, square, sawtooth).
  */
 function generateTone(trackIndex, startTime, duration, frequency, amplitude) {
     try {
@@ -17927,7 +17927,7 @@ function generateTone(trackIndex, startTime, duration, frequency, amplitude) {
 }
 
 /**
- * duplicateTimelineSection — Copy a section of timeline to another position.
+ * duplicateTimelineSection - Copy a section of timeline to another position.
  */
 function duplicateTimelineSection(startTime, endTime, destTime) {
     try {
@@ -17963,7 +17963,7 @@ function duplicateTimelineSection(startTime, endTime, destTime) {
 }
 
 /**
- * repeatTimelineSection — Repeat a section of timeline N times.
+ * repeatTimelineSection - Repeat a section of timeline N times.
  */
 function repeatTimelineSection(startTime, endTime, count) {
     try {
@@ -17984,7 +17984,7 @@ function repeatTimelineSection(startTime, endTime, count) {
 }
 
 /**
- * mirrorTimeline — Mirror/reverse the entire timeline.
+ * mirrorTimeline - Mirror/reverse the entire timeline.
  */
 function mirrorTimeline() {
     try {
@@ -18012,7 +18012,7 @@ function mirrorTimeline() {
 }
 
 /**
- * splitTimelineAtPlayhead — Split timeline into two sequences at playhead position.
+ * splitTimelineAtPlayhead - Split timeline into two sequences at playhead position.
  */
 function splitTimelineAtPlayhead() {
     try {
@@ -18056,7 +18056,7 @@ function splitTimelineAtPlayhead() {
 }
 
 /**
- * getTimelineGapReport — Detailed report of all gaps on the timeline.
+ * getTimelineGapReport - Detailed report of all gaps on the timeline.
  */
 function getTimelineGapReport() {
     try {
@@ -18091,7 +18091,7 @@ function getTimelineGapReport() {
 }
 
 /**
- * getTimelineConflictReport — Report overlapping clips.
+ * getTimelineConflictReport - Report overlapping clips.
  */
 function getTimelineConflictReport() {
     try {
@@ -18124,7 +18124,7 @@ function getTimelineConflictReport() {
 }
 
 /**
- * getTimelineEffectsReport — Report all effects used on timeline.
+ * getTimelineEffectsReport - Report all effects used on timeline.
  */
 function getTimelineEffectsReport() {
     try {
@@ -18161,7 +18161,7 @@ function getTimelineEffectsReport() {
 }
 
 /**
- * getTimelineDurationBreakdown — Duration breakdown by clip type/source.
+ * getTimelineDurationBreakdown - Duration breakdown by clip type/source.
  */
 function getTimelineDurationBreakdown() {
     try {
@@ -18197,7 +18197,7 @@ function getTimelineDurationBreakdown() {
 }
 
 /**
- * getTimelineTrackUsageReport — Report track usage (empty/used time per track).
+ * getTimelineTrackUsageReport - Report track usage (empty/used time per track).
  */
 function getTimelineTrackUsageReport() {
     try {
@@ -18231,7 +18231,7 @@ function getTimelineTrackUsageReport() {
 // ---------------------------------------------------------------------------
 
 /**
- * getExportSettingsForPreset — Get detailed encoding settings from an export preset file.
+ * getExportSettingsForPreset - Get detailed encoding settings from an export preset file.
  */
 function getExportSettingsForPreset(presetPath) {
     try {
@@ -18271,7 +18271,7 @@ function getExportSettingsForPreset(presetPath) {
 }
 
 /**
- * createCustomExportSettings — Create custom export settings object.
+ * createCustomExportSettings - Create custom export settings object.
  * @param {string} settingsJson - JSON with codec, bitrate, resolution, fps, audio fields.
  */
 function createCustomExportSettings(settingsJson) {
@@ -18294,7 +18294,7 @@ function createCustomExportSettings(settingsJson) {
 }
 
 /**
- * getAvailableCodecs — List all available video codecs (via exporter list).
+ * getAvailableCodecs - List all available video codecs (via exporter list).
  */
 function getAvailableCodecs() {
     try {
@@ -18321,7 +18321,7 @@ function getAvailableCodecs() {
 }
 
 /**
- * getAvailableAudioCodecs — List all available audio codecs.
+ * getAvailableAudioCodecs - List all available audio codecs.
  */
 function getAvailableAudioCodecs() {
     try {
@@ -18340,7 +18340,7 @@ function getAvailableAudioCodecs() {
 }
 
 /**
- * getAvailableContainers — List available container formats.
+ * getAvailableContainers - List available container formats.
  */
 function getAvailableContainers() {
     try {
@@ -18363,7 +18363,7 @@ function getAvailableContainers() {
 // ---------------------------------------------------------------------------
 
 /**
- * convertToProRes — Convert a project item to Apple ProRes.
+ * convertToProRes - Convert a project item to Apple ProRes.
  * @param {number} projectItemIndex - Zero-based project item index.
  * @param {string} variant - ProRes variant: "422", "4444", "LT", "Proxy".
  * @param {string} outputPath - Output file path.
@@ -18402,7 +18402,7 @@ function convertToProRes(projectItemIndex, variant, outputPath) {
 }
 
 /**
- * convertToH264 — Convert a project item to H.264.
+ * convertToH264 - Convert a project item to H.264.
  */
 function convertToH264(projectItemIndex, outputPath, bitrate) {
     try {
@@ -18431,7 +18431,7 @@ function convertToH264(projectItemIndex, outputPath, bitrate) {
 }
 
 /**
- * convertToH265 — Convert a project item to H.265/HEVC.
+ * convertToH265 - Convert a project item to H.265/HEVC.
  */
 function convertToH265(projectItemIndex, outputPath, bitrate) {
     try {
@@ -18460,7 +18460,7 @@ function convertToH265(projectItemIndex, outputPath, bitrate) {
 }
 
 /**
- * convertToDNxHR — Convert a project item to DNxHR.
+ * convertToDNxHR - Convert a project item to DNxHR.
  * @param {string} profile - DNxHR profile: "LB", "SQ", "HQ", "HQX", "444".
  */
 function convertToDNxHR(projectItemIndex, outputPath, profile) {
@@ -18494,7 +18494,7 @@ function convertToDNxHR(projectItemIndex, outputPath, profile) {
 }
 
 /**
- * convertToGIF — Export a sequence as an animated GIF.
+ * convertToGIF - Export a sequence as an animated GIF.
  */
 function convertToGIF(sequenceIndex, outputPath, width, fps) {
     try {
@@ -18528,7 +18528,7 @@ function convertToGIF(sequenceIndex, outputPath, width, fps) {
 // ---------------------------------------------------------------------------
 
 /**
- * generateClipThumbnail — Generate a thumbnail image from a clip at a given time offset.
+ * generateClipThumbnail - Generate a thumbnail image from a clip at a given time offset.
  */
 function generateClipThumbnail(projectItemIndex, timeOffset, outputPath) {
     try {
@@ -18558,7 +18558,7 @@ function generateClipThumbnail(projectItemIndex, timeOffset, outputPath) {
 }
 
 /**
- * generateSequenceThumbnail — Generate a thumbnail image from a sequence at a given time.
+ * generateSequenceThumbnail - Generate a thumbnail image from a sequence at a given time.
  */
 function generateSequenceThumbnail(sequenceIndex, timeOffset, outputPath) {
     try {
@@ -18586,7 +18586,7 @@ function generateSequenceThumbnail(sequenceIndex, timeOffset, outputPath) {
 }
 
 /**
- * generateContactSheet — Generate a contact sheet (grid of thumbnails) from a clip.
+ * generateContactSheet - Generate a contact sheet (grid of thumbnails) from a clip.
  */
 function generateContactSheet(projectItemIndex, outputPath, cols, rows) {
     try {
@@ -18626,7 +18626,7 @@ function generateContactSheet(projectItemIndex, outputPath, cols, rows) {
 }
 
 /**
- * generateStoryboard — Generate storyboard frames from a sequence at regular intervals.
+ * generateStoryboard - Generate storyboard frames from a sequence at regular intervals.
  */
 function generateStoryboard(sequenceIndex, outputPath, interval) {
     try {
@@ -18671,7 +18671,7 @@ function generateStoryboard(sequenceIndex, outputPath, interval) {
 // ---------------------------------------------------------------------------
 
 /**
- * analyzeMediaCodec — Detailed codec analysis for a project item.
+ * analyzeMediaCodec - Detailed codec analysis for a project item.
  */
 function analyzeMediaCodec(projectItemIndex) {
     try {
@@ -18727,7 +18727,7 @@ function analyzeMediaCodec(projectItemIndex) {
 }
 
 /**
- * compareMediaSpecs — Compare specs of two project items.
+ * compareMediaSpecs - Compare specs of two project items.
  */
 function compareMediaSpecs(itemIndex1, itemIndex2) {
     try {
@@ -18769,7 +18769,7 @@ function compareMediaSpecs(itemIndex1, itemIndex2) {
 }
 
 /**
- * getBitRateInfo — Get bitrate information for a project item.
+ * getBitRateInfo - Get bitrate information for a project item.
  */
 function getBitRateInfo(projectItemIndex) {
     try {
@@ -18817,7 +18817,7 @@ function getBitRateInfo(projectItemIndex) {
 }
 
 /**
- * getColorDepthInfo — Get color depth and chroma subsampling for a project item.
+ * getColorDepthInfo - Get color depth and chroma subsampling for a project item.
  */
 function getColorDepthInfo(projectItemIndex) {
     try {
@@ -18856,7 +18856,7 @@ function getColorDepthInfo(projectItemIndex) {
 }
 
 /**
- * getAudioSpecsDetailed — Detailed audio specs for a project item.
+ * getAudioSpecsDetailed - Detailed audio specs for a project item.
  */
 function getAudioSpecsDetailed(projectItemIndex) {
     try {
@@ -18899,7 +18899,7 @@ function getAudioSpecsDetailed(projectItemIndex) {
 }
 
 /**
- * isVariableFrameRate — Check if a clip has variable frame rate.
+ * isVariableFrameRate - Check if a clip has variable frame rate.
  */
 function isVariableFrameRate(projectItemIndex) {
     try {
@@ -18937,7 +18937,7 @@ function isVariableFrameRate(projectItemIndex) {
 // ---------------------------------------------------------------------------
 
 /**
- * getFileHash — Get a file hash for a project item's media file.
+ * getFileHash - Get a file hash for a project item's media file.
  * Note: ExtendScript lacks native crypto; this does a basic checksum.
  */
 function getFileHash(projectItemIndex, algorithm) {
@@ -18969,7 +18969,7 @@ function getFileHash(projectItemIndex, algorithm) {
 }
 
 /**
- * getFileDates — Get creation/modification dates for a project item's media file.
+ * getFileDates - Get creation/modification dates for a project item's media file.
  */
 function getFileDates(projectItemIndex) {
     try {
@@ -18994,7 +18994,7 @@ function getFileDates(projectItemIndex) {
 }
 
 /**
- * moveMediaFile — Move media file to a new directory and relink in project.
+ * moveMediaFile - Move media file to a new directory and relink in project.
  */
 function moveMediaFile(projectItemIndex, newDirectory) {
     try {
@@ -19031,7 +19031,7 @@ function moveMediaFile(projectItemIndex, newDirectory) {
 }
 
 /**
- * copyMediaFile — Copy a project item's media file to a destination directory.
+ * copyMediaFile - Copy a project item's media file to a destination directory.
  */
 function copyMediaFile(projectItemIndex, destDirectory) {
     try {
@@ -19063,7 +19063,7 @@ function copyMediaFile(projectItemIndex, destDirectory) {
 }
 
 /**
- * renameMediaFile — Rename a media file on disk and relink in the project.
+ * renameMediaFile - Rename a media file on disk and relink in the project.
  */
 function renameMediaFile(projectItemIndex, newName) {
     try {
@@ -19106,7 +19106,7 @@ function renameMediaFile(projectItemIndex, newName) {
 // ---------------------------------------------------------------------------
 
 /**
- * addToRenderQueue — Add a sequence to Premiere Pro's internal render queue.
+ * addToRenderQueue - Add a sequence to Premiere Pro's internal render queue.
  */
 function addToRenderQueue(sequenceIndex, presetPath, outputPath) {
     try {
@@ -19138,7 +19138,7 @@ function addToRenderQueue(sequenceIndex, presetPath, outputPath) {
 }
 
 /**
- * getRenderQueueStatus — Get the current render queue status.
+ * getRenderQueueStatus - Get the current render queue status.
  */
 function getRenderQueueStatus() {
     try {
@@ -19158,7 +19158,7 @@ function getRenderQueueStatus() {
 }
 
 /**
- * clearRenderQueue — Clear the render queue.
+ * clearRenderQueue - Clear the render queue.
  */
 function clearRenderQueue() {
     try {
@@ -19172,7 +19172,7 @@ function clearRenderQueue() {
 }
 
 /**
- * pauseRenderQueue — Pause rendering.
+ * pauseRenderQueue - Pause rendering.
  */
 function pauseRenderQueue() {
     try {
@@ -19184,7 +19184,7 @@ function pauseRenderQueue() {
 }
 
 /**
- * resumeRenderQueue — Resume rendering.
+ * resumeRenderQueue - Resume rendering.
  */
 function resumeRenderQueue() {
     try {
@@ -21980,7 +21980,7 @@ function createApprovalPackage(sequenceIndex, outputDir) {
         var rpt = "=== APPROVAL PACKAGE ===\nSequence: "+seq.name+"\nDate: "+new Date().toISOString()+"\nDuration: "+dur.toFixed(2)+"s\nClips: "+tc+"\n";
         var folder = new Folder(pkgDir); folder.create();
         var rf = new File(pkg.reportPath); rf.open("w"); rf.write(rpt); rf.close();
-        return _ok({ sequence: seq.name, package: pkg, duration: dur, clipCount: tc });
+        return _ok({ sequence: seq.name, "package": pkg, duration: dur, clipCount: tc });
     } catch (e) { return _err("createApprovalPackage failed: " + e.message); }
 }
 
@@ -22831,7 +22831,7 @@ function setTimelineViewExtents(startSeconds, endSeconds) {
 // ---------------------------------------------------------------------------
 
 /**
- * getClipCameraInfo — Get camera metadata (make, model, lens, ISO, shutter, aperture)
+ * getClipCameraInfo - Get camera metadata (make, model, lens, ISO, shutter, aperture)
  * from XMP metadata embedded in the media file.
  */
 function getClipCameraInfo(projectItemIndex) {
@@ -22869,7 +22869,7 @@ function getClipCameraInfo(projectItemIndex) {
 }
 
 /**
- * getClipGPSInfo — Get GPS coordinates from XMP metadata.
+ * getClipGPSInfo - Get GPS coordinates from XMP metadata.
  */
 function getClipGPSInfo(projectItemIndex) {
     try {
@@ -22897,7 +22897,7 @@ function getClipGPSInfo(projectItemIndex) {
 }
 
 /**
- * getClipRecordDate — Get recording date/time from XMP metadata.
+ * getClipRecordDate - Get recording date/time from XMP metadata.
  */
 function getClipRecordDate(projectItemIndex) {
     try {
@@ -22923,7 +22923,7 @@ function getClipRecordDate(projectItemIndex) {
 }
 
 /**
- * sortClipsByRecordDate — Sort clips in a bin by recording date.
+ * sortClipsByRecordDate - Sort clips in a bin by recording date.
  * Reads XMP DateTimeOriginal/CreateDate and returns sorted order.
  */
 function sortClipsByRecordDate(binPath) {
@@ -22974,7 +22974,7 @@ function sortClipsByRecordDate(binPath) {
 }
 
 /**
- * groupClipsByCamera — Group clips by camera make/model into bins.
+ * groupClipsByCamera - Group clips by camera make/model into bins.
  * Creates sub-bins named after camera model and moves matching clips.
  */
 function groupClipsByCamera(binPath) {
@@ -23039,7 +23039,7 @@ function groupClipsByCamera(binPath) {
 // ---------------------------------------------------------------------------
 
 /**
- * markShotType — Mark a clip with a shot type using a marker (wide, medium, closeup, insert, cutaway).
+ * markShotType - Mark a clip with a shot type using a marker (wide, medium, closeup, insert, cutaway).
  */
 function markShotType(trackType, trackIndex, clipIndex, shotType) {
     try {
@@ -23068,7 +23068,7 @@ function markShotType(trackType, trackIndex, clipIndex, shotType) {
 }
 
 /**
- * getShotType — Get shot type marker from a clip.
+ * getShotType - Get shot type marker from a clip.
  */
 function getShotType(trackType, trackIndex, clipIndex) {
     try {
@@ -23095,7 +23095,7 @@ function getShotType(trackType, trackIndex, clipIndex) {
 }
 
 /**
- * filterByShotType — Get all clips in a sequence matching a specific shot type.
+ * filterByShotType - Get all clips in a sequence matching a specific shot type.
  */
 function filterByShotType(sequenceIndex, shotType) {
     try {
@@ -23130,7 +23130,7 @@ function filterByShotType(sequenceIndex, shotType) {
 }
 
 /**
- * createShotList — Export a shot list from a sequence to a file.
+ * createShotList - Export a shot list from a sequence to a file.
  */
 function createShotList(sequenceIndex, outputPath) {
     try {
@@ -23186,7 +23186,7 @@ function createShotList(sequenceIndex, outputPath) {
 }
 
 /**
- * importShotList — Import a shot list from CSV and apply shot types to timeline clips.
+ * importShotList - Import a shot list from CSV and apply shot types to timeline clips.
  */
 function importShotList(csvPath, sequenceIndex) {
     try {
@@ -23246,7 +23246,7 @@ function importShotList(csvPath, sequenceIndex) {
 // ---------------------------------------------------------------------------
 
 /**
- * markScene — Mark a clip with a scene number using a marker.
+ * markScene - Mark a clip with a scene number using a marker.
  */
 function markScene(trackType, trackIndex, clipIndex, sceneNumber) {
     try {
@@ -23275,7 +23275,7 @@ function markScene(trackType, trackIndex, clipIndex, sceneNumber) {
 }
 
 /**
- * markTake — Mark a clip with a take number using a marker.
+ * markTake - Mark a clip with a take number using a marker.
  */
 function markTake(trackType, trackIndex, clipIndex, takeNumber) {
     try {
@@ -23304,7 +23304,7 @@ function markTake(trackType, trackIndex, clipIndex, takeNumber) {
 }
 
 /**
- * getBestTake — Get the longest/marked-best take for a scene number across all tracks.
+ * getBestTake - Get the longest/marked-best take for a scene number across all tracks.
  */
 function getBestTake(sceneNumber) {
     try {
@@ -23344,7 +23344,7 @@ function getBestTake(sceneNumber) {
 }
 
 /**
- * organizeByScenesAndTakes — Auto-organize project items by parsing scene/take from filenames.
+ * organizeByScenesAndTakes - Auto-organize project items by parsing scene/take from filenames.
  * Expected naming: S01T01_*, Scene1_Take2_*, etc.
  */
 function organizeByScenesAndTakes() {
@@ -23400,7 +23400,7 @@ function organizeByScenesAndTakes() {
 }
 
 /**
- * getSceneList — Get all scenes with their takes from the active sequence.
+ * getSceneList - Get all scenes with their takes from the active sequence.
  */
 function getSceneList() {
     try {
@@ -23447,7 +23447,7 @@ function getSceneList() {
 // ---------------------------------------------------------------------------
 
 /**
- * matchCameraSettings — Compare camera settings between two project items.
+ * matchCameraSettings - Compare camera settings between two project items.
  */
 function matchCameraSettings(clip1Index, clip2Index) {
     try {
@@ -23498,7 +23498,7 @@ function matchCameraSettings(clip1Index, clip2Index) {
 }
 
 /**
- * findClipsFromSameCamera — Find all clips shot with the same camera as the given clip.
+ * findClipsFromSameCamera - Find all clips shot with the same camera as the given clip.
  */
 function findClipsFromSameCamera(projectItemIndex) {
     try {
@@ -23549,7 +23549,7 @@ function findClipsFromSameCamera(projectItemIndex) {
 }
 
 /**
- * createMulticamByCamera — Create a multicam sequence grouping clips by camera make/model.
+ * createMulticamByCamera - Create a multicam sequence grouping clips by camera make/model.
  */
 function createMulticamByCamera(outputName) {
     try {
@@ -23607,7 +23607,7 @@ function createMulticamByCamera(outputName) {
 // ---------------------------------------------------------------------------
 
 /**
- * getSourceTimecode — Get original source timecode from a project item.
+ * getSourceTimecode - Get original source timecode from a project item.
  */
 function getSourceTimecode(projectItemIndex) {
     try {
@@ -23642,7 +23642,7 @@ function getSourceTimecode(projectItemIndex) {
 }
 
 /**
- * setSourceTimecodeOffset — Set source timecode offset on a project item via XMP.
+ * setSourceTimecodeOffset - Set source timecode offset on a project item via XMP.
  */
 function setSourceTimecodeOffset(projectItemIndex, offset) {
     try {
@@ -23662,7 +23662,7 @@ function setSourceTimecodeOffset(projectItemIndex, offset) {
 }
 
 /**
- * syncByTimecode — Sync clips across specified tracks by aligning their source timecodes.
+ * syncByTimecode - Sync clips across specified tracks by aligning their source timecodes.
  */
 function syncByTimecode(trackIndicesJson) {
     try {
@@ -23702,7 +23702,7 @@ function syncByTimecode(trackIndicesJson) {
 }
 
 /**
- * findTimecodeBreaks — Find gaps in timecode continuity on a track.
+ * findTimecodeBreaks - Find gaps in timecode continuity on a track.
  */
 function findTimecodeBreaks(trackType, trackIndex) {
     try {
@@ -23741,7 +23741,7 @@ function findTimecodeBreaks(trackType, trackIndex) {
 // ---------------------------------------------------------------------------
 
 /**
- * rateClip — Rate a clip (1-5 stars) by setting XMP rating metadata.
+ * rateClip - Rate a clip (1-5 stars) by setting XMP rating metadata.
  */
 function rateClip(projectItemIndex, rating) {
     try {
@@ -23762,7 +23762,7 @@ function rateClip(projectItemIndex, rating) {
 }
 
 /**
- * getClipRating — Get clip rating from XMP metadata.
+ * getClipRating - Get clip rating from XMP metadata.
  */
 function getClipRating(projectItemIndex) {
     try {
@@ -23785,7 +23785,7 @@ function getClipRating(projectItemIndex) {
 }
 
 /**
- * filterByRating — Get all project items with rating >= minRating.
+ * filterByRating - Get all project items with rating >= minRating.
  */
 function filterByRating(minRating) {
     try {
@@ -23816,7 +23816,7 @@ function filterByRating(minRating) {
 }
 
 /**
- * getTopRatedClips — Get top N rated clips, sorted by rating descending.
+ * getTopRatedClips - Get top N rated clips, sorted by rating descending.
  */
 function getTopRatedClips(count) {
     try {
@@ -23854,7 +23854,7 @@ function getTopRatedClips(count) {
 // ---------------------------------------------------------------------------
 
 /**
- * setClipNote — Set a text note on a project item via XMP dc:description.
+ * setClipNote - Set a text note on a project item via XMP dc:description.
  */
 function setClipNote(projectItemIndex, note) {
     try {
@@ -23874,7 +23874,7 @@ function setClipNote(projectItemIndex, note) {
 }
 
 /**
- * getClipNote — Get clip note from XMP dc:description.
+ * getClipNote - Get clip note from XMP dc:description.
  */
 function getClipNote(projectItemIndex) {
     try {
@@ -23896,7 +23896,7 @@ function getClipNote(projectItemIndex) {
 }
 
 /**
- * searchClipNotes — Search all clip notes for a text string.
+ * searchClipNotes - Search all clip notes for a text string.
  */
 function searchClipNotes(searchText) {
     try {
@@ -23926,7 +23926,7 @@ function searchClipNotes(searchText) {
 }
 
 /**
- * exportClipNotes — Export all clip notes as CSV or JSON to a file.
+ * exportClipNotes - Export all clip notes as CSV or JSON to a file.
  */
 function exportClipNotes(outputPath, format) {
     try {
@@ -23982,7 +23982,7 @@ function exportClipNotes(outputPath, format) {
 // ---------------------------------------------------------------------------
 
 /**
- * 1. snapshotTimeline(sequenceIndex) — Create a JSON snapshot of timeline state.
+ * 1. snapshotTimeline(sequenceIndex) - Create a JSON snapshot of timeline state.
  */
 function snapshotTimeline(sequenceIndex) {
     try {
@@ -24042,7 +24042,7 @@ function snapshotTimeline(sequenceIndex) {
 }
 
 /**
- * 2. compareTimelineSnapshots(snapshot1Json, snapshot2Json) — Diff two timeline snapshots.
+ * 2. compareTimelineSnapshots(snapshot1Json, snapshot2Json) - Diff two timeline snapshots.
  */
 function compareTimelineSnapshots(snapshot1Json, snapshot2Json) {
     try {
@@ -24104,7 +24104,7 @@ function compareTimelineSnapshots(snapshot1Json, snapshot2Json) {
 }
 
 /**
- * 3. getTimelineChanges(sequenceIndex, sinceTimestamp) — Get changes since timestamp.
+ * 3. getTimelineChanges(sequenceIndex, sinceTimestamp) - Get changes since timestamp.
  */
 function getTimelineChanges(sequenceIndex, sinceTimestamp) {
     try {
@@ -24124,7 +24124,7 @@ function getTimelineChanges(sequenceIndex, sinceTimestamp) {
 }
 
 /**
- * 4. highlightChangedClips(sequenceIndex, changedClipIds) — Select/highlight changed clips.
+ * 4. highlightChangedClips(sequenceIndex, changedClipIds) - Select/highlight changed clips.
  */
 function highlightChangedClips(sequenceIndex, changedClipIds) {
     try {
@@ -24155,7 +24155,7 @@ function highlightChangedClips(sequenceIndex, changedClipIds) {
 }
 
 /**
- * 5. revertClipToSnapshot(trackType, trackIndex, clipIndex, snapshotJson) — Revert clip to snapshot state.
+ * 5. revertClipToSnapshot(trackType, trackIndex, clipIndex, snapshotJson) - Revert clip to snapshot state.
  */
 function revertClipToSnapshot(trackType, trackIndex, clipIndex, snapshotJson) {
     try {
@@ -24200,7 +24200,7 @@ function revertClipToSnapshot(trackType, trackIndex, clipIndex, snapshotJson) {
 // ---------------------------------------------------------------------------
 
 /**
- * 6. saveSequenceVersion(sequenceIndex, versionName, notes) — Save named version.
+ * 6. saveSequenceVersion(sequenceIndex, versionName, notes) - Save named version.
  */
 function saveSequenceVersion(sequenceIndex, versionName, notes) {
     try {
@@ -24228,7 +24228,7 @@ function saveSequenceVersion(sequenceIndex, versionName, notes) {
 }
 
 /**
- * 7. listSequenceVersions(sequenceIndex) — List all saved versions.
+ * 7. listSequenceVersions(sequenceIndex) - List all saved versions.
  */
 function listSequenceVersions(sequenceIndex) {
     try {
@@ -24263,7 +24263,7 @@ function listSequenceVersions(sequenceIndex) {
 }
 
 /**
- * 8. loadSequenceVersion(sequenceIndex, versionName) — Load a saved version.
+ * 8. loadSequenceVersion(sequenceIndex, versionName) - Load a saved version.
  */
 function loadSequenceVersion(sequenceIndex, versionName) {
     try {
@@ -24291,7 +24291,7 @@ function loadSequenceVersion(sequenceIndex, versionName) {
 }
 
 /**
- * 9. deleteSequenceVersion(sequenceIndex, versionName) — Delete a version.
+ * 9. deleteSequenceVersion(sequenceIndex, versionName) - Delete a version.
  */
 function deleteSequenceVersion(sequenceIndex, versionName) {
     try {
@@ -24310,7 +24310,7 @@ function deleteSequenceVersion(sequenceIndex, versionName) {
 }
 
 /**
- * 10. mergeSequenceVersions(baseVersion, overlayVersion, strategy) — Merge two versions.
+ * 10. mergeSequenceVersions(baseVersion, overlayVersion, strategy) - Merge two versions.
  */
 function mergeSequenceVersions(baseVersion, overlayVersion, strategy) {
     try {
@@ -24373,7 +24373,7 @@ function mergeSequenceVersions(baseVersion, overlayVersion, strategy) {
 // ---------------------------------------------------------------------------
 
 /**
- * 11. createABComparison(seqIndexA, seqIndexB) — Set up side-by-side comparison.
+ * 11. createABComparison(seqIndexA, seqIndexB) - Set up side-by-side comparison.
  */
 function createABComparison(seqIndexA, seqIndexB) {
     try {
@@ -24400,7 +24400,7 @@ function createABComparison(seqIndexA, seqIndexB) {
 }
 
 /**
- * 12. switchABView(view) — Switch between A, B, or split view.
+ * 12. switchABView(view) - Switch between A, B, or split view.
  */
 function switchABView(view) {
     try {
@@ -24416,7 +24416,7 @@ function switchABView(view) {
 }
 
 /**
- * 13. getABDifferences(seqIndexA, seqIndexB) — List differences between A and B.
+ * 13. getABDifferences(seqIndexA, seqIndexB) - List differences between A and B.
  */
 function getABDifferences(seqIndexA, seqIndexB) {
     try {
@@ -24435,7 +24435,7 @@ function getABDifferences(seqIndexA, seqIndexB) {
 // ---------------------------------------------------------------------------
 
 /**
- * 14. getClipboardContents() — Get clipboard contents info.
+ * 14. getClipboardContents() - Get clipboard contents info.
  */
 function getClipboardContents() {
     try {
@@ -24458,7 +24458,7 @@ function getClipboardContents() {
 }
 
 /**
- * 15. clearClipboard() — Clear editing clipboard.
+ * 15. clearClipboard() - Clear editing clipboard.
  */
 function clearClipboard() {
     try {
@@ -24483,7 +24483,7 @@ function clearClipboard() {
 }
 
 /**
- * 16. clipboardHasContent() — Check if clipboard has content.
+ * 16. clipboardHasContent() - Check if clipboard has content.
  */
 function clipboardHasContent() {
     try {
@@ -24502,7 +24502,7 @@ function clipboardHasContent() {
 // ---------------------------------------------------------------------------
 
 /**
- * 17. getUndoHistory(count) — Get undo history entries.
+ * 17. getUndoHistory(count) - Get undo history entries.
  */
 function getUndoHistory(count) {
     try {
@@ -24520,7 +24520,7 @@ function getUndoHistory(count) {
 }
 
 /**
- * 18. getUndoCount() — Get available undo count.
+ * 18. getUndoCount() - Get available undo count.
  */
 function getUndoCount() {
     try {
@@ -24537,7 +24537,7 @@ function getUndoCount() {
 }
 
 /**
- * 19. undoMultiple(count) — Undo multiple steps.
+ * 19. undoMultiple(count) - Undo multiple steps.
  */
 function undoMultiple(count) {
     try {
@@ -24557,7 +24557,7 @@ function undoMultiple(count) {
 }
 
 /**
- * 20. redoMultiple(count) — Redo multiple steps.
+ * 20. redoMultiple(count) - Redo multiple steps.
  */
 function redoMultiple(count) {
     try {
@@ -24581,7 +24581,7 @@ function redoMultiple(count) {
 // ---------------------------------------------------------------------------
 
 /**
- * 21. createProjectBackup(outputPath, includeMedia) — Create full project backup.
+ * 21. createProjectBackup(outputPath, includeMedia) - Create full project backup.
  */
 function createProjectBackup(outputPath, includeMedia) {
     try {
@@ -24632,7 +24632,7 @@ function createProjectBackup(outputPath, includeMedia) {
 }
 
 /**
- * 22. getAutoSaveVersions() — List auto-save versions.
+ * 22. getAutoSaveVersions() - List auto-save versions.
  */
 function getAutoSaveVersions() {
     try {
@@ -24659,7 +24659,7 @@ function getAutoSaveVersions() {
 }
 
 /**
- * 23. restoreAutoSave(versionPath) — Restore from auto-save.
+ * 23. restoreAutoSave(versionPath) - Restore from auto-save.
  */
 function restoreAutoSave(versionPath) {
     try {
@@ -24672,7 +24672,7 @@ function restoreAutoSave(versionPath) {
 }
 
 /**
- * 24. setAutoSaveNow() — Trigger immediate auto-save.
+ * 24. setAutoSaveNow() - Trigger immediate auto-save.
  */
 function setAutoSaveNow() {
     try {
@@ -24694,7 +24694,7 @@ function setAutoSaveNow() {
 }
 
 /**
- * 25. getBackupSchedule() — Get backup schedule info.
+ * 25. getBackupSchedule() - Get backup schedule info.
  */
 function getBackupSchedule() {
     try {
@@ -24733,7 +24733,7 @@ function getBackupSchedule() {
 // ---------------------------------------------------------------------------
 
 /**
- * 26. upgradeProjectVersion(projectPath) — Upgrade older project file.
+ * 26. upgradeProjectVersion(projectPath) - Upgrade older project file.
  */
 function upgradeProjectVersion(projectPath) {
     try {
@@ -24747,7 +24747,7 @@ function upgradeProjectVersion(projectPath) {
 }
 
 /**
- * 27. getProjectVersion(projectPath) — Get project file version.
+ * 27. getProjectVersion(projectPath) - Get project file version.
  */
 function getProjectVersion(projectPath) {
     try {
@@ -24779,7 +24779,7 @@ function getProjectVersion(projectPath) {
 }
 
 /**
- * 28. exportProjectForOlderVersion(outputPath, targetVersion) — Save for older Premiere Pro.
+ * 28. exportProjectForOlderVersion(outputPath, targetVersion) - Save for older Premiere Pro.
  */
 function exportProjectForOlderVersion(outputPath, targetVersion) {
     try {
@@ -24811,7 +24811,7 @@ function exportProjectForOlderVersion(outputPath, targetVersion) {
 }
 
 /**
- * 29. checkProjectCompatibility(projectPath) — Check compatibility with current version.
+ * 29. checkProjectCompatibility(projectPath) - Check compatibility with current version.
  */
 function checkProjectCompatibility(projectPath) {
     try {
@@ -24852,7 +24852,7 @@ function checkProjectCompatibility(projectPath) {
 }
 
 /**
- * 30. importProjectFromOtherNLE(sourcePath, sourceFormat) — Import from DaVinci/FCPX/Avid.
+ * 30. importProjectFromOtherNLE(sourcePath, sourceFormat) - Import from DaVinci/FCPX/Avid.
  */
 function importProjectFromOtherNLE(sourcePath, sourceFormat) {
     try {

--- a/cep-panel/src/host/premiere.jsx
+++ b/cep-panel/src/host/premiere.jsx
@@ -2266,7 +2266,68 @@ function insertBarsAndTone(paramsJson) {
     }
 }
 
-// getSequenceMarkers — implemented in core.jsx (always loaded); keeps EvalCommand working if premiere.jsx fails to $.evalFile.
+// Bundle scripted marker edits into one undo step when the host supports it.
+function _runWithUndoGroup(undoLabel, fn) {
+    var opened = false;
+    var label = undoLabel || "Script";
+    try {
+        if (typeof app !== "undefined" && app && typeof app.beginUndoGroup === "function") {
+            app.beginUndoGroup(label);
+            opened = true;
+        }
+        return fn();
+    } finally {
+        if (opened && typeof app.endUndoGroup === "function") {
+            try {
+                app.endUndoGroup();
+            } catch (endE) {}
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// getSequenceMarkers() - Get all markers on the active sequence
+// ---------------------------------------------------------------------------
+function getSequenceMarkers() {
+    try {
+        if (!app.project) {
+            return _err("No project is open");
+        }
+
+        var seq = app.project.activeSequence;
+        if (!seq) {
+            return _err("No active sequence");
+        }
+
+        var markers = [];
+        if (seq.markers) {
+            var marker = seq.markers.getFirstMarker();
+            var idx = 0;
+            while (marker) {
+                markers.push({
+                    index: idx,
+                    name: marker.name || "",
+                    comment: marker.comments || "",
+                    start: _timeToSeconds(marker.start),
+                    end: _timeToSeconds(marker.end),
+                    type: marker.type || "",
+                    colorIndex: marker.colorIndex !== undefined ? marker.colorIndex : -1
+                });
+                idx++;
+                marker = seq.markers.getNextMarker(marker);
+            }
+        }
+
+        return _ok({
+            count: markers.length,
+            markers: markers,
+            sequenceName: seq.name || "",
+            sequenceID: seq.sequenceID || ""
+        });
+    } catch (e) {
+        return _err("getSequenceMarkers failed: " + e.message);
+    }
+}
 
 // ---------------------------------------------------------------------------
 // addSequenceMarker(paramsJson) - Add a marker to the active sequence
@@ -2293,27 +2354,29 @@ function addSequenceMarker(paramsJson) {
             return _err("Sequence does not support markers");
         }
 
-        var newMarker = seq.markers.createMarker(time);
-        if (newMarker) {
+        var ret = null;
+        _runWithUndoGroup("Add sequence marker", function () {
+            var newMarker = seq.markers.createMarker(time);
+            if (!newMarker) {
+                throw new Error("Failed to create marker");
+            }
             if (name !== "") newMarker.name = name;
             if (comment !== "") newMarker.comments = comment;
             if (color >= 0) newMarker.colorIndex = color;
             if (duration > 0) {
                 newMarker.end = _secondsToTime(time + duration);
             }
-        } else {
-            return _err("Failed to create marker");
-        }
-
-        return _ok({
-            name: name,
-            comment: comment,
-            time: time,
-            duration: duration,
-            color: color,
-            sequenceName: seq.name || "",
-            sequenceID: seq.sequenceID || ""
+            ret = _ok({
+                name: name,
+                comment: comment,
+                time: time,
+                duration: duration,
+                color: color,
+                sequenceName: seq.name || "",
+                sequenceID: seq.sequenceID || ""
+            });
         });
+        return ret;
     } catch (e) {
         return _err("addSequenceMarker failed: " + e.message);
     }
@@ -2342,29 +2405,32 @@ function deleteSequenceMarker(markerIndex) {
             return _err("Invalid marker index: " + markerIndex);
         }
 
-        // Navigate to the target marker by index
-        var marker = seq.markers.getFirstMarker();
-        var idx = 0;
-        while (marker && idx < markerIndex) {
-            marker = seq.markers.getNextMarker(marker);
-            idx++;
-        }
+        var ret = null;
+        _runWithUndoGroup("Delete sequence marker", function () {
+            var marker = seq.markers.getFirstMarker();
+            var idx = 0;
+            while (marker && idx < markerIndex) {
+                marker = seq.markers.getNextMarker(marker);
+                idx++;
+            }
 
-        if (!marker) {
-            return _err("Marker index " + markerIndex + " not found");
-        }
+            if (!marker) {
+                throw new Error("Marker index " + markerIndex + " not found");
+            }
 
-        var deletedName = marker.name || "";
-        var deletedTime = _timeToSeconds(marker.start);
-        seq.markers.deleteMarker(marker);
+            var deletedName = marker.name || "";
+            var deletedTime = _timeToSeconds(marker.start);
+            seq.markers.deleteMarker(marker);
 
-        return _ok({
-            deletedIndex: markerIndex,
-            deletedName: deletedName,
-            deletedTime: deletedTime,
-            sequenceName: seq.name || "",
-            sequenceID: seq.sequenceID || ""
+            ret = _ok({
+                deletedIndex: markerIndex,
+                deletedName: deletedName,
+                deletedTime: deletedTime,
+                sequenceName: seq.name || "",
+                sequenceID: seq.sequenceID || ""
+            });
         });
+        return ret;
     } catch (e) {
         return _err("deleteSequenceMarker failed: " + e.message);
     }
@@ -7093,9 +7159,13 @@ function addClipMarker(trackType, trackIndex, clipIndex, time, name, comment, co
         if (!track.clips || clipIndex >= track.clips.numItems) return _err("Clip index out of range");
         var clip = track.clips[clipIndex];
         if (!clip.markers) return _err("Clip does not support markers");
-        var marker = clip.markers.createMarker(time);
-        if (marker) { marker.name = name; marker.comments = comment; if (marker.setColorByIndex) { marker.setColorByIndex(color); } }
-        return _ok({ trackType: trackType, trackIndex: trackIndex, clipIndex: clipIndex, markerTime: time, markerName: name, markerComment: comment, markerColor: color });
+        var ret;
+        _runWithUndoGroup("Add clip marker", function () {
+            var marker = clip.markers.createMarker(time);
+            if (marker) { marker.name = name; marker.comments = comment; if (marker.setColorByIndex) { marker.setColorByIndex(color); } }
+            ret = _ok({ trackType: trackType, trackIndex: trackIndex, clipIndex: clipIndex, markerTime: time, markerName: name, markerComment: comment, markerColor: color });
+        });
+        return ret;
     } catch (e) { return _err("addClipMarker failed: " + e.message); }
 }
 
@@ -7134,8 +7204,12 @@ function deleteClipMarker(trackType, trackIndex, clipIndex, markerIndex) {
         while (marker && idx < markerIndex) { marker = clip.markers.getNextMarker(marker); idx++; }
         if (!marker) return _err("Marker index " + markerIndex + " out of range");
         var markerName = marker.name || "";
-        clip.markers.deleteMarker(marker);
-        return _ok({ trackType: trackType, trackIndex: trackIndex, clipIndex: clipIndex, markerIndex: markerIndex, deletedMarkerName: markerName, deleted: true });
+        var ret;
+        _runWithUndoGroup("Delete clip marker", function () {
+            clip.markers.deleteMarker(marker);
+            ret = _ok({ trackType: trackType, trackIndex: trackIndex, clipIndex: clipIndex, markerIndex: markerIndex, deletedMarkerName: markerName, deleted: true });
+        });
+        return ret;
     } catch (e) { return _err("deleteClipMarker failed: " + e.message); }
 }
 
@@ -9262,17 +9336,19 @@ function importMarkersFromCSV(csvPath) {
         var file = new File(csvPath); if (!file.exists) return _err("CSV file not found: " + csvPath);
         file.encoding = "UTF-8"; file.open("r"); var content = file.read(); file.close();
         var lines = content.split(/\r?\n/); var imported = 0; var markers = seq.markers;
-        for (var i = 1; i < lines.length; i++) {
-            var line = lines[i].replace(/^\s+|\s+$/g, ""); if (!line) continue;
-            var parts = line.split(","); if (parts.length < 3) continue;
-            var name = parts[0] || ""; var comment = parts[1] || "";
-            var startSec = parseFloat(parts[2]) || 0; var endSec = parseFloat(parts[3]) || startSec;
-            var colorIdx = parseInt(parts[4], 10) || 0;
-            try {
-                var newMarker = markers.createMarker(startSec);
-                if (newMarker) { newMarker.name = name; newMarker.comments = comment; if (endSec > startSec) newMarker.end = _secondsToTime(endSec); if (colorIdx > 0 && newMarker.setColorByIndex) newMarker.setColorByIndex(colorIdx); imported++; }
-            } catch (me) {}
-        }
+        _runWithUndoGroup("Import markers from CSV", function () {
+            for (var i = 1; i < lines.length; i++) {
+                var line = lines[i].replace(/^\s+|\s+$/g, ""); if (!line) continue;
+                var parts = line.split(","); if (parts.length < 3) continue;
+                var name = parts[0] || ""; var comment = parts[1] || "";
+                var startSec = parseFloat(parts[2]) || 0; var endSec = parseFloat(parts[3]) || startSec;
+                var colorIdx = parseInt(parts[4], 10) || 0;
+                try {
+                    var newMarker = markers.createMarker(startSec);
+                    if (newMarker) { newMarker.name = name; newMarker.comments = comment; if (endSec > startSec) newMarker.end = _secondsToTime(endSec); if (colorIdx > 0 && newMarker.setColorByIndex) newMarker.setColorByIndex(colorIdx); imported++; }
+                } catch (me) {}
+            }
+        });
         return _ok({csvPath: csvPath, markersImported: imported});
     } catch (e) { return _err("importMarkersFromCSV failed: " + e.message); }
 }
@@ -9282,10 +9358,12 @@ function deleteAllMarkers() {
         if (!app.project) return _err("No project is open");
         var seq = app.project.activeSequence; if (!seq) return _err("No active sequence");
         var markers = seq.markers; if (!markers) return _err("Sequence has no markers object");
-        var toDelete = []; var marker = markers.getFirstMarker();
-        while (marker) { toDelete.push(marker); marker = markers.getNextMarker(marker); }
         var count = 0;
-        for (var i = 0; i < toDelete.length; i++) { try { markers.deleteMarker(toDelete[i]); count++; } catch (de) {} }
+        _runWithUndoGroup("Delete all sequence markers", function () {
+            var toDelete = []; var marker = markers.getFirstMarker();
+            while (marker) { toDelete.push(marker); marker = markers.getNextMarker(marker); }
+            for (var i = 0; i < toDelete.length; i++) { try { markers.deleteMarker(toDelete[i]); count++; } catch (de) {} }
+        });
         return _ok({markersDeleted: count});
     } catch (e) { return _err("deleteAllMarkers failed: " + e.message); }
 }
@@ -15466,17 +15544,19 @@ function addChapterMarkers(chaptersJSON) {
         var chapters = JSON.parse(chaptersJSON);
         if (!chapters || chapters.length === 0) return _err("No chapters provided");
         var added = 0;
-        for (var i = 0; i < chapters.length; i++) {
-            var ch = chapters[i];
-            var time = parseFloat(ch.time) || 0;
-            var title = ch.title || ("Chapter " + (i + 1));
-            try {
-                var marker = seq.markers.createMarker(time);
-                marker.name = title;
-                marker.comments = "Chapter marker";
-                added++;
-            } catch (me) {}
-        }
+        _runWithUndoGroup("Add chapter markers", function () {
+            for (var i = 0; i < chapters.length; i++) {
+                var ch = chapters[i];
+                var time = parseFloat(ch.time) || 0;
+                var title = ch.title || ("Chapter " + (i + 1));
+                try {
+                    var marker = seq.markers.createMarker(time);
+                    marker.name = title;
+                    marker.comments = "Chapter marker";
+                    added++;
+                } catch (me) {}
+            }
+        });
         return _ok({chaptersAdded: added, totalChapters: chapters.length});
     } catch (e) { return _err("addChapterMarkers failed: " + e.message); }
 }

--- a/cep-panel/src/host/premiere.jsx
+++ b/cep-panel/src/host/premiere.jsx
@@ -2362,7 +2362,13 @@ function addSequenceMarker(paramsJson) {
             }
             if (name !== "") newMarker.name = name;
             if (comment !== "") newMarker.comments = comment;
-            if (color >= 0) newMarker.colorIndex = color;
+            if (color >= 0) {
+                if (newMarker.setColorByIndex) {
+                    newMarker.setColorByIndex(color);
+                } else {
+                    newMarker.colorIndex = color;
+                }
+            }
             if (duration > 0) {
                 newMarker.end = _secondsToTime(time + duration);
             }
@@ -5396,6 +5402,95 @@ function importCaptions(filePath, format) {
     } catch (e) { return _err("importCaptions failed: " + e.message); }
 }
 
+function _parseEvalArgs(argsJson) {
+    if (argsJson === undefined || argsJson === null || argsJson === "") return {};
+    if (typeof argsJson === "object") return argsJson;
+    var o = _tryParseJSONObjectString(String(argsJson));
+    if (o) return o;
+    try { return JSON.parse(String(argsJson)); } catch (e) { return {}; }
+}
+
+function _getSequenceFps(seq) {
+    var fps = parseFloat(seq.timebase);
+    if (!fps || isNaN(fps) || fps <= 0) fps = 30;
+    return fps;
+}
+
+function _secondsToTimecode(seconds, fps) {
+    var rate = fps > 0 ? fps : 30;
+    var totalFrames = Math.max(0, Math.round(parseFloat(seconds) * rate));
+    var h = Math.floor(totalFrames / (rate * 3600));
+    var m = Math.floor((totalFrames % (rate * 3600)) / (rate * 60));
+    var s = Math.floor((totalFrames % (rate * 60)) / rate);
+    var f = totalFrames % rate;
+    function pad2(n) { return (n < 10 ? "0" : "") + n; }
+    return pad2(h) + ":" + pad2(m) + ":" + pad2(s) + ":" + pad2(f);
+}
+
+function _extractCaptionClipText(clip) {
+    if (!clip) return "";
+    var text = clip.name || "";
+    var tryMgt = !text || /\.(mp4|mov|mxf|wav|mp3|m4a|aac)$/i.test(text);
+    if (tryMgt && clip.getMGTComponent) {
+        try {
+            var comp = clip.getMGTComponent();
+            if (comp && comp.properties) {
+                for (var pi = 0; pi < comp.properties.numItems; pi++) {
+                    var p = comp.properties[pi];
+                    var dn = (p.displayName || "").toLowerCase();
+                    if (dn === "source text" || dn === "text" || dn.indexOf("caption") >= 0) {
+                        try {
+                            var val = p.getValue();
+                            if (val !== undefined && val !== null && String(val).replace(/\s/g, "").length > 0) {
+                                text = String(val);
+                                break;
+                            }
+                        } catch (pe) { continue; }
+                    }
+                }
+            }
+        } catch (e) { /* ignore */ }
+    }
+    return String(text || "").replace(/^\s+|\s+$/g, "");
+}
+
+function _collectSequenceCaptions(seq, trackIndex) {
+    var captions = [];
+    if (!seq.captionTracks || seq.captionTracks.numTracks === 0) return captions;
+    var startTrack = 0;
+    var endTrack = seq.captionTracks.numTracks - 1;
+    if (trackIndex !== undefined && trackIndex !== null && trackIndex !== "") {
+        var ti = parseInt(trackIndex, 10);
+        if (!isNaN(ti) && ti >= 0 && ti < seq.captionTracks.numTracks) {
+            startTrack = ti;
+            endTrack = ti;
+        }
+    }
+    for (var t = startTrack; t <= endTrack; t++) {
+        var ct = seq.captionTracks[t];
+        if (!ct || !ct.clips) continue;
+        for (var ci = 0; ci < ct.clips.numItems; ci++) {
+            var c = ct.clips[ci];
+            var text = _extractCaptionClipText(c);
+            if (!text) continue;
+            captions.push({
+                trackIndex: t,
+                index: ci,
+                text: text,
+                speaker: "Unknown",
+                startSeconds: _timeToSeconds(c.start),
+                endSeconds: _timeToSeconds(c.end),
+                duration: _timeToSeconds(c.duration)
+            });
+        }
+    }
+    captions.sort(function (a, b) {
+        if (a.startSeconds !== b.startSeconds) return a.startSeconds - b.startSeconds;
+        return a.trackIndex - b.trackIndex;
+    });
+    return captions;
+}
+
 function getCaptions(trackIndex) {
     try {
         if (!app.project) return _err("No project is open");
@@ -5405,7 +5500,19 @@ function getCaptions(trackIndex) {
         var captions = [];
         if (seq.captionTracks && trackIndex < seq.captionTracks.numTracks) {
             var ct = seq.captionTracks[trackIndex];
-            if (ct && ct.clips) { for (var ci = 0; ci < ct.clips.numItems; ci++) { var c = ct.clips[ci]; captions.push({ index: ci, text: c.name || "", startSeconds: _timeToSeconds(c.start), endSeconds: _timeToSeconds(c.end), duration: _timeToSeconds(c.duration) }); } }
+            if (ct && ct.clips) {
+                for (var ci = 0; ci < ct.clips.numItems; ci++) {
+                    var c = ct.clips[ci];
+                    captions.push({
+                        index: ci,
+                        text: _extractCaptionClipText(c),
+                        startSeconds: _timeToSeconds(c.start),
+                        endSeconds: _timeToSeconds(c.end),
+                        duration: _timeToSeconds(c.duration)
+                    });
+                }
+            }
+        } else if (trackIndex < seq.videoTracks.numTracks) {
         } else if (trackIndex < seq.videoTracks.numTracks) {
             var vt = seq.videoTracks[trackIndex];
             if (vt && vt.clips) { for (var vc = 0; vc < vt.clips.numItems; vc++) { var v = vt.clips[vc]; captions.push({ index: vc, text: v.name || "", startSeconds: _timeToSeconds(v.start), endSeconds: _timeToSeconds(v.end), duration: _timeToSeconds(v.duration) }); } }
@@ -5489,6 +5596,111 @@ function exportCaptions(outputPath, format) {
         var f = new File(outputPath); f.open("w"); f.write(content); f.close();
         return _ok({ outputPath: outputPath, format: format, captionCount: captions.length, exported: true });
     } catch (e) { return _err("exportCaptions failed: " + e.message); }
+}
+
+/**
+ * Caption-track fallback for premiere_export_sequence_transcript on Premiere 24.x
+ * (and when the UXP Text-panel bridge is unavailable). Requires captions created
+ * from Speech-to-Text via Text > Create Captions (or an imported caption track).
+ */
+function exportSequenceTranscript(argsJson) {
+    try {
+        var args = _parseEvalArgs(argsJson);
+        var outputPath = args.outputPath || args.output_path || "";
+        var format = String(args.format || "prtranscript").toLowerCase();
+        var speakerLabel = args.speakerLabel || args.speaker_label || "Unknown";
+        var trackIndex = args.trackIndex !== undefined ? args.trackIndex : args.track_index;
+
+        if (!outputPath || outputPath === "") return _err("outputPath is required");
+        if (!app.project) return _err("No project is open");
+        var seq = app.project.activeSequence;
+        if (!seq) return _err("No active sequence");
+
+        var fps = _getSequenceFps(seq);
+        var captions = _collectSequenceCaptions(seq, trackIndex);
+        var seqDuration = _timeToSeconds(seq.end);
+
+        // Drop a single full-span caption whose text looks like a source media filename.
+        if (captions.length === 1 && seqDuration > 0) {
+            var lone = captions[0];
+            if ((lone.endSeconds - lone.startSeconds) >= seqDuration * 0.9 &&
+                /\.(mp4|mov|mxf|wav|mp3|m4a|aac)$/i.test(lone.text)) {
+                captions = [];
+            }
+        }
+
+        if (captions.length === 0) {
+            return _err(
+                "No caption-track transcript found on the active sequence. " +
+                "In Text > Transcript, use Create Captions (or add a caption track), then retry. " +
+                "On Premiere 25.0+, the UXP bridge can export Text-panel transcripts without captions."
+            );
+        }
+
+        var segments = [];
+        for (var i = 0; i < captions.length; i++) {
+            var cap = captions[i];
+            segments.push({
+                startSeconds: cap.startSeconds,
+                endSeconds: cap.endSeconds,
+                speaker: speakerLabel || cap.speaker || "Unknown",
+                text: cap.text
+            });
+        }
+
+        var content;
+        if (format === "json") {
+            content = JSON.stringify({
+                sequenceName: seq.name || "",
+                fps: fps,
+                segmentCount: segments.length,
+                segments: segments,
+                stats: {
+                    captionCount: captions.length,
+                    captionTrackCount: seq.captionTracks ? seq.captionTracks.numTracks : 0,
+                    source: "caption_tracks"
+                }
+            }, null, 2);
+        } else if (format === "text" || format === "txt") {
+            var plain = [];
+            for (var ti = 0; ti < segments.length; ti++) {
+                var seg = segments[ti];
+                plain.push("[" + seg.startSeconds.toFixed(3) + "] " + seg.speaker + ": " + seg.text);
+            }
+            content = plain.join("\n").trim() + (plain.length ? "\n" : "");
+        } else {
+            var lines = [];
+            for (var pi = 0; pi < segments.length; pi++) {
+                var s = segments[pi];
+                if (!s.text) continue;
+                lines.push(_secondsToTimecode(s.startSeconds, fps) + " - " + _secondsToTimecode(s.endSeconds, fps));
+                lines.push(s.speaker || speakerLabel || "Unknown");
+                lines.push(s.text);
+                lines.push("");
+            }
+            content = lines.join("\n").trim() + (lines.length ? "\n" : "");
+        }
+
+        var outFile = new File(outputPath);
+        outFile.encoding = "UTF-8";
+        if (!outFile.parent.exists) outFile.parent.create();
+        if (!outFile.open("w")) return _err("Failed to open output file: " + outputPath);
+        outFile.write(content);
+        outFile.close();
+
+        return _ok({
+            outputPath: outputPath,
+            format: format,
+            segmentCount: segments.length,
+            sequenceName: seq.name || "",
+            fps: fps,
+            captionCount: captions.length,
+            captionTrackCount: seq.captionTracks ? seq.captionTracks.numTracks : 0,
+            source: "caption_tracks",
+            uxpTranscriptApi: false,
+            note: "Exported from caption tracks (CEP fallback). Create captions from Text > Transcript for best parity with Text-panel export."
+        });
+    } catch (e) { return _err("exportSequenceTranscript failed: " + e.message); }
 }
 
 function styleCaptions(trackIndex, font, size, color, bgColor, position) {

--- a/cep-panel/src/panel.js
+++ b/cep-panel/src/panel.js
@@ -296,18 +296,21 @@
             var fn = p.function_name || "";
             var argsJson = p.args_json || "";
 
-            // Build lazy-load prefix: if the function doesn't exist yet,
-            // load the full premiere.jsx (once) to make it available.
-            var loadScript = "";
-            if (!premiereJsxLoaded) {
-                loadScript =
-                    'if (typeof ' + fn + ' !== "function") { ' +
-                    '  try { $.evalFile("' + premiereJsxPath + '"); } catch(loadErr) {} ' +
-                    '} ';
-            }
+            // Before every evalCommand: if fn is missing, load premiere.jsx.
+            // Always emit this guard — never skip it based on premiereJsxLoaded.
+            // A prior bug set that flag after the first successful evalCommand even when
+            // only core.jsx ran (e.g. getSequenceList), leaving premiere-only helpers
+            // unloaded and causing "EvalScript error" on clips/MOGRT APIs.
+            var loadScript =
+                'if (typeof ' + fn + ' !== "function") { ' +
+                '  try { $.evalFile("' + premiereJsxPath + '"); } catch(loadErr) {} ' +
+                '} ';
 
             var callScript;
-            if (argsJson && argsJson !== "{}" && argsJson !== "[]") {
+            var expanded = expandEvalCommandArgs(fn, argsJson);
+            if (expanded !== null && expanded !== undefined) {
+                callScript = expanded;
+            } else if (argsJson && argsJson !== "{}" && argsJson !== "[]") {
                 callScript = fn + "(" + escapeForEval(argsJson) + ")";
             } else {
                 callScript = fn + "()";
@@ -325,6 +328,55 @@
         if (str === undefined || str === null) { str = ""; }
         str = String(str);
         return "'" + str.replace(/\\/g, "\\\\").replace(/'/g, "\\'") + "'";
+    }
+
+    /** Go sends evalCommand(fn, "{\"a\":...}") — expand into positional ExtendScript calls. */
+    function expandEvalCommandArgs(fn, argsJson) {
+        if (!argsJson || typeof argsJson !== "string") return null;
+        if (argsJson.charAt(0) !== "{") return null;
+        var po;
+        try { po = JSON.parse(argsJson); } catch (e0) { return null; }
+
+        var ti;
+        var ci;
+        var pi;
+        var txt;
+        var pn;
+        var val;
+
+        if (fn === "getClipsOnTrack") {
+            var tt = po.trackType || po.track_type || "video";
+            ti = po.trackIndex !== undefined ? po.trackIndex : po.track_index;
+            if (ti === undefined || ti === null) ti = 0;
+            return fn + "(" + escapeForEval(String(tt)) + "," + Number(ti) + ")";
+        }
+        if (fn === "getMOGRTProperties") {
+            ti = po.trackIndex !== undefined ? po.trackIndex : po.track_index;
+            ci = po.clipIndex !== undefined ? po.clipIndex : po.clip_index;
+            if (ti === undefined || ti === null) ti = 0;
+            if (ci === undefined || ci === null) ci = 0;
+            return fn + "(" + Number(ti) + "," + Number(ci) + ")";
+        }
+        if (fn === "setMOGRTText") {
+            ti = po.trackIndex !== undefined ? po.trackIndex : po.track_index;
+            ci = po.clipIndex !== undefined ? po.clipIndex : po.clip_index;
+            pi = po.propertyIndex !== undefined ? po.propertyIndex : po.property_index;
+            txt = po.text !== undefined && po.text !== null ? String(po.text) : "";
+            if (ti === undefined || ti === null) ti = 0;
+            if (ci === undefined || ci === null) ci = 0;
+            if (pi === undefined || pi === null) pi = 0;
+            return fn + "(" + Number(ti) + "," + Number(ci) + "," + Number(pi) + "," + escapeForEval(txt) + ")";
+        }
+        if (fn === "setMOGRTProperty") {
+            ti = po.trackIndex !== undefined ? po.trackIndex : po.track_index;
+            ci = po.clipIndex !== undefined ? po.clipIndex : po.clip_index;
+            pn = po.propertyName || po.property_name || "";
+            val = po.value !== undefined && po.value !== null ? String(po.value) : "";
+            if (ti === undefined || ti === null) ti = 0;
+            if (ci === undefined || ci === null) ci = 0;
+            return fn + "(" + Number(ti) + "," + Number(ci) + "," + escapeForEval(pn) + "," + escapeForEval(val) + ")";
+        }
+        return null;
     }
 
     // ---------------------------------------------------------------------------
@@ -382,12 +434,6 @@
             } catch (e) {
                 // If it's not JSON, return it as a plain string value
                 result = rawResult;
-            }
-
-            // If this was a successful evalCommand, premiere.jsx is now loaded
-            if (action === "evalCommand" && !premiereJsxLoaded) {
-                premiereJsxLoaded = true;
-                log("premiere.jsx loaded (lazy)", "success");
             }
 
             log("Done: " + action + " [" + requestId.substring(0, 8) + "]", "success");

--- a/cep-panel/src/panel.js
+++ b/cep-panel/src/panel.js
@@ -44,7 +44,7 @@
 
     // Lazy-loading state for the full premiere.jsx ExtendScript library
     var premiereJsxLoaded = false;
-    var premiereJsxPath = path.join(__dirname, "host", "premiere.jsx").replace(/\\/g, "/");
+    var premiereJsxPath = resolveHostScriptPath("premiere.jsx");
 
     // Stats tracking
     var stats = {
@@ -58,6 +58,19 @@
 
     // In-flight command timers: requestId -> start timestamp
     var commandTimers = {};
+
+    function resolveHostScriptPath(fileName) {
+        var candidates = [
+            path.join(__dirname, "host", fileName),
+            path.join(__dirname, "src", "host", fileName),
+        ];
+        for (var i = 0; i < candidates.length; i++) {
+            if (fs.existsSync(candidates[i])) {
+                return candidates[i].replace(/\\/g, "/");
+            }
+        }
+        return candidates[0].replace(/\\/g, "/");
+    }
 
     // ---------------------------------------------------------------------------
     // UI element references
@@ -546,20 +559,40 @@
     // Load ExtendScript host functions
     // ---------------------------------------------------------------------------
     function loadHostScript() {
-        var corePath = path.join(__dirname, "host", "core.jsx").replace(/\\/g, "/");
+        var corePath = resolveHostScriptPath("core.jsx");
+        var coreEval = [
+            "(function(){",
+            "try {",
+            "  $.evalFile(\"" + corePath + "\");",
+            "  return \"OK\";",
+            "} catch (e) {",
+            "  return \"ERROR: \" + e.name + \": \" + e.message + \" @ line \" + e.line;",
+            "}",
+            "}())",
+        ].join("");
+        var premiereEval = [
+            "(function(){",
+            "try {",
+            "  $.evalFile(\"" + premiereJsxPath + "\");",
+            "  return \"OK\";",
+            "} catch (e) {",
+            "  return \"ERROR: \" + e.name + \": \" + e.message + \" @ line \" + e.line;",
+            "}",
+            "}())",
+        ].join("");
         log("Loading core ExtendScript: " + corePath);
-        csInterface.evalScript('$.evalFile("' + corePath + '")', function (result) {
-            if (result === "EvalScript error.") {
-                log("Failed to load core.jsx -- ExtendScript error", "error");
+        csInterface.evalScript(coreEval, function (result) {
+            if (result !== "OK") {
+                log("Failed to load core.jsx -- " + result, "error");
             } else {
                 log("Core ExtendScript loaded", "success");
                 // Eagerly attempt to load the full premiere.jsx in the background.
                 // If it fails (too large for $.evalFile), functions will be
                 // lazy-loaded on the first evalCommand call instead.
                 log("Loading extended functions from premiere.jsx...");
-                csInterface.evalScript('$.evalFile("' + premiereJsxPath + '")', function (result2) {
-                    if (result2 === "EvalScript error.") {
-                        log("Extended functions will be loaded on first use (lazy)", "info");
+                csInterface.evalScript(premiereEval, function (result2) {
+                    if (result2 !== "OK") {
+                        log("Extended functions will be loaded on first use (lazy): " + result2, "info");
                     } else {
                         premiereJsxLoaded = true;
                         log("All ExtendScript functions loaded", "success");

--- a/cep-panel/src/panel.js
+++ b/cep-panel/src/panel.js
@@ -376,6 +376,11 @@
             if (ci === undefined || ci === null) ci = 0;
             return fn + "(" + Number(ti) + "," + Number(ci) + "," + escapeForEval(pn) + "," + escapeForEval(val) + ")";
         }
+        if (fn === "exportFrame") {
+            var outPath = po.output_path || po.outputPath || "";
+            var imgFmt = po.format || "PNG";
+            return fn + "(" + escapeForEval(outPath) + "," + escapeForEval(imgFmt) + ")";
+        }
         return null;
     }
 

--- a/docs/premiere-pro-api-reference.md
+++ b/docs/premiere-pro-api-reference.md
@@ -118,8 +118,36 @@ osascript -e 'tell application "Adobe Premiere Pro 2025" to do script "app.proje
 
 Cross Dissolve, Dip to Black, Dip to White, Film Dissolve, Wipe, Barn Doors, Push, Slide, Morph Cut, Constant Power (audio), Constant Gain (audio)
 
-## 10. Future: UXP
+## 10. Sequence Transcript Export
+
+| MCP tool | Purpose |
+|----------|---------|
+| `premiere_export_sequence_transcript` | Export transcript to `prtranscript`, `json`, or `text` |
+
+### Premiere 25.0+ (Text panel via UXP)
+
+Speech-to-Text data in **Text > Transcript** is read through the UXP bridge
+(ExtendScript cannot access it directly).
+
+1. Source clips transcribed in **Text > Transcript**
+2. **PremierPro MCP UXP Bridge** panel open and connected (`ws://127.0.0.1:9802`)
+3. Enable developer mode: **Edit > Preferences > Plugins** (Premiere 25.6+)
+
+Install UXP panel: `scripts/install-uxp-panel-win.bat` (Windows) or `just install-uxp-panel` (macOS).
+
+### Premiere 24.x (caption-track fallback via CEP)
+
+When UXP is unavailable, ts-bridge exports **caption tracks** instead:
+
+1. Transcribe in **Text > Transcript**
+2. **Create Captions** from that transcript (adds a caption track)
+3. Call `premiere_export_sequence_transcript` — uses CEP automatically
+
+Caption export is a workaround: speaker labels default to `Unknown`, and block
+boundaries follow caption segments rather than Text-panel blocks.
+
+## 11. ExtendScript Sunset
 
 - ExtendScript/CEP supported through September 2026
-- UXP is the future but currently beta-only for Premiere Pro
-- CEP + ExtendScript is the correct choice for now
+- CEP + ExtendScript remains the primary bridge for timeline/markers/export
+- Text-panel transcript readback requires UXP on Premiere 25.0+; caption fallback covers 24.x

--- a/go-orchestrator/cmd/server/main.go
+++ b/go-orchestrator/cmd/server/main.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"runtime"
 	"syscall"
+	"time"
 
 	mcpserver "github.com/mark3labs/mcp-go/server"
 	"go.uber.org/zap"
@@ -14,6 +16,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/anthropics/premierpro-mcp/go-orchestrator/internal/config"
+	"github.com/anthropics/premierpro-mcp/go-orchestrator/internal/embeddedbridge"
 	grpcclients "github.com/anthropics/premierpro-mcp/go-orchestrator/internal/grpc"
 	"github.com/anthropics/premierpro-mcp/go-orchestrator/internal/mcp"
 	"github.com/anthropics/premierpro-mcp/go-orchestrator/internal/orchestrator"
@@ -36,9 +39,10 @@ func main() {
 func run() error {
 	// ── Flags ──────────────────────────────────────────────────────────
 	var (
-		transport = flag.String("transport", "", `MCP transport: "stdio" (default) or "sse"`)
-		port      = flag.Int("port", 0, "SSE HTTP port (only used with --transport=sse)")
-		logLevel  = flag.String("log-level", "", `Log level: "debug", "info", "warn", "error"`)
+		transport   = flag.String("transport", "", `MCP transport: "stdio" (default) or "sse"`)
+		port        = flag.Int("port", 0, "SSE HTTP port (only used with --transport=sse)")
+		logLevel    = flag.String("log-level", "", `Log level: "debug", "info", "warn", "error"`)
+		embedBridge = flag.Bool("embed-ts-bridge", false, "Windows only: spawn the TypeScript gRPC bridge in a Job Object that dies when server.exe terminates (recommended for Cursor MCP)")
 	)
 	flag.Parse()
 
@@ -72,6 +76,23 @@ func run() error {
 		zap.String("built", date),
 		zap.String("transport", string(cfg.Transport)),
 	)
+
+	var stopEmbedded func()
+	if *embedBridge {
+		if runtime.GOOS != "windows" {
+			return fmt.Errorf("--embed-ts-bridge is only supported on Windows")
+		}
+		var ebErr error
+		stopEmbedded, ebErr = embeddedbridge.Start(logger)
+		if ebErr != nil {
+			return ebErr
+		}
+		// Matches cursor-mcp-launcher delay — gRPC listens after node boot.
+		time.Sleep(2 * time.Second)
+	}
+	if stopEmbedded != nil {
+		defer stopEmbedded()
+	}
 
 	// ── gRPC client connections ───────────────────────────────────────
 	clients, err := grpcclients.NewClients(&grpcclients.ClientsConfig{

--- a/go-orchestrator/go.mod
+++ b/go-orchestrator/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/mark3labs/mcp-go v0.45.0
 	go.uber.org/zap v1.27.1
 	golang.org/x/sync v0.20.0
+	golang.org/x/sys v0.39.0
 	google.golang.org/grpc v1.79.3
 )
 
@@ -23,7 +24,6 @@ require (
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/net v0.48.0 // indirect
-	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/go-orchestrator/internal/embeddedbridge/launch_unix.go
+++ b/go-orchestrator/internal/embeddedbridge/launch_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package embeddedbridge
+
+import (
+	"fmt"
+	"go.uber.org/zap"
+)
+
+// Start is not implemented on this platform (-embed-ts-bridge is Windows-only).
+func Start(_ *zap.Logger) (func(), error) {
+	return nil, fmt.Errorf("embeddedbridge: -embed-ts-bridge is only supported on Windows")
+}

--- a/go-orchestrator/internal/embeddedbridge/launch_windows.go
+++ b/go-orchestrator/internal/embeddedbridge/launch_windows.go
@@ -1,0 +1,98 @@
+//go:build windows
+
+package embeddedbridge
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"unsafe"
+
+	"go.uber.org/zap"
+	"golang.org/x/sys/windows"
+)
+
+// Start spawns the TypeScript bridge (node ts-bridge/dist/index.js) in a Win32 Job Object
+// with JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE. When server.exe terminates for any reason, the OS
+// closes handles for the dead process → last job handle closes → node is forcibly terminated.
+func Start(logger *zap.Logger) (stop func(), err error) {
+	exePath, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("embeddedbridge: Executable: %w", err)
+	}
+	binDir := filepath.Dir(exePath)
+	goOrchRoot := filepath.Clean(filepath.Join(binDir, ".."))
+	repoRoot := filepath.Clean(filepath.Join(goOrchRoot, ".."))
+	bridgeWD := filepath.Join(repoRoot, "ts-bridge")
+	bridgeJS := filepath.Join(bridgeWD, "dist", "index.js")
+
+	if _, err := os.Stat(bridgeJS); err != nil {
+		return nil, fmt.Errorf("embeddedbridge: missing bridge script %s: %w", bridgeJS, err)
+	}
+	nodeExe, err := exec.LookPath("node.exe")
+	if err != nil {
+		nodeExe, err = exec.LookPath("node")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("embeddedbridge: node not on PATH: %w", err)
+	}
+
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("embeddedbridge: CreateJobObject: %w", err)
+	}
+
+	var info windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+	info.BasicLimitInformation.LimitFlags = windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+	_, err = windows.SetInformationJobObject(
+		job,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+	)
+	if err != nil {
+		_ = windows.CloseHandle(job)
+		return nil, fmt.Errorf("embeddedbridge: SetInformationJobObject(KILL_ON_JOB_CLOSE): %w", err)
+	}
+
+	cmd := exec.Command(nodeExe, bridgeJS)
+	cmd.Dir = bridgeWD
+	cmd.Stdout = io.Discard
+	cmd.Stderr = os.Stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windows.CREATE_BREAKAWAY_FROM_JOB,
+	}
+
+	if err := cmd.Start(); err != nil {
+		_ = windows.CloseHandle(job)
+		return nil, fmt.Errorf("embeddedbridge: starting node: %w", err)
+	}
+
+	procH, err := windows.OpenProcess(windows.PROCESS_ALL_ACCESS, false, uint32(cmd.Process.Pid))
+	if err != nil {
+		_ = cmd.Process.Kill()
+		_ = windows.CloseHandle(job)
+		return nil, fmt.Errorf("embeddedbridge: OpenProcess(pid=%d): %w", cmd.Process.Pid, err)
+	}
+	if err := windows.AssignProcessToJobObject(job, procH); err != nil {
+		_ = windows.CloseHandle(procH)
+		_ = cmd.Process.Kill()
+		_ = windows.CloseHandle(job)
+		return nil, fmt.Errorf("embeddedbridge: AssignProcessToJobObject: %w", err)
+	}
+	_ = windows.CloseHandle(procH)
+
+	logger.Info("embedded ts-bridge started under kill-on-close job",
+		zap.Int("pid", cmd.Process.Pid),
+		zap.String("script", bridgeJS),
+	)
+
+	return func() {
+		if err := windows.CloseHandle(job); err != nil {
+			logger.Warn("embeddedbridge: CloseHandle(job)", zap.Error(err))
+		}
+	}, nil
+}

--- a/go-orchestrator/internal/mcp/graphics_tools.go
+++ b/go-orchestrator/internal/mcp/graphics_tools.go
@@ -287,6 +287,34 @@ func registerGraphicsTools(s *server.MCPServer, orch Orchestrator, logger *zap.L
 	)
 
 	s.AddTool(
+		gomcp.NewTool("premiere_export_sequence_transcript",
+			gomcp.WithDescription("Export transcript data for the active sequence to prtranscript, json, or text. On Premiere 25.0+ with the UXP bridge connected, reads Text-panel Speech-to-Text data from source clips. On Premiere 24.x (or when UXP is unavailable), falls back to caption tracks — create captions from Text > Transcript first."),
+			gomcp.WithString("output_path", gomcp.Required(), gomcp.Description("Absolute path for the output transcript file")),
+			gomcp.WithString("format", gomcp.Description("Output format: 'prtranscript' (default, HH:MM:SS:FF blocks), 'json', or 'text'"), gomcp.Enum("prtranscript", "json", "text")),
+			gomcp.WithString("speaker_label", gomcp.Description("Fallback speaker label when Premiere does not name a speaker (default: 'Unknown')")),
+			gomcp.WithBoolean("include_audio_tracks", gomcp.Description("Also scan audio track items for clip transcripts (default: false)")),
+		),
+		func(ctx context.Context, req gomcp.CallToolRequest) (*gomcp.CallToolResult, error) {
+			logger.Debug("handling premiere_export_sequence_transcript")
+			outputPath := gomcp.ParseString(req, "output_path", "")
+			if outputPath == "" {
+				return gomcp.NewToolResultError("parameter 'output_path' is required"), nil
+			}
+			result, err := orch.ExportSequenceTranscript(
+				ctx,
+				outputPath,
+				gomcp.ParseString(req, "format", "prtranscript"),
+				gomcp.ParseString(req, "speaker_label", "Unknown"),
+				gomcp.ParseBoolean(req, "include_audio_tracks", false),
+			)
+			if err != nil {
+				return gomcp.NewToolResultError(fmt.Sprintf("failed to export sequence transcript: %v", err)), nil
+			}
+			return toolResultJSON(result)
+		},
+	)
+
+	s.AddTool(
 		gomcp.NewTool("premiere_style_captions",
 			gomcp.WithDescription("Style all captions on a track (font, size, color, background, position)."),
 			gomcp.WithNumber("track_index", gomcp.Description("Zero-based caption track index (default: 0)")),

--- a/go-orchestrator/internal/orchestrator/capture_ops.go
+++ b/go-orchestrator/internal/orchestrator/capture_ops.go
@@ -35,6 +35,9 @@ func (e *Engine) CaptureFrameAsBase64(ctx context.Context) (*FrameCaptureResult,
 		return nil, fmt.Errorf("CaptureFrameAsBase64: failed to parse response: %w", err)
 	}
 	if !resp.Success {
+		if fb, fbErr := e.captureFrameBase64ViaFFmpeg(ctx, 0); fbErr == nil {
+			return fb, nil
+		}
 		return nil, fmt.Errorf("CaptureFrameAsBase64: %s", resp.Error)
 	}
 

--- a/go-orchestrator/internal/orchestrator/eval_unpack.go
+++ b/go-orchestrator/internal/orchestrator/eval_unpack.go
@@ -1,0 +1,16 @@
+package orchestrator
+
+import "encoding/json"
+
+// unwrapExtendScriptEnvelope strips the _ok()/panel wrapper {"success":true,"data":...}
+// when present, so unmarshaling into protobuf-shaped structs succeeds.
+func unwrapExtendScriptEnvelope(result string) []byte {
+	var top struct {
+		Success bool            `json:"success"`
+		Data    json.RawMessage `json:"data"`
+	}
+	if json.Unmarshal([]byte(result), &top) != nil || !top.Success || len(top.Data) == 0 {
+		return []byte(result)
+	}
+	return top.Data
+}

--- a/go-orchestrator/internal/orchestrator/export_extended.go
+++ b/go-orchestrator/internal/orchestrator/export_extended.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 )
 
 // ---------------------------------------------------------------------------
@@ -60,14 +61,27 @@ func (e *Engine) ExportFrame(ctx context.Context, params *ExportFrameParams) (*G
 	if params.OutputPath == "" {
 		return nil, fmt.Errorf("export frame: output_path must not be empty")
 	}
-	argsJSON, _ := json.Marshal(map[string]any{
-		"params": params,
-	})
+	argsJSON, _ := json.Marshal(params)
 	result, err := e.premiere.EvalCommand(ctx, "exportFrame", string(argsJSON))
 	if err != nil {
-		return nil, fmt.Errorf("ExportFrame: %w", err)
+		return e.exportFrameWithFallback(ctx, params, err)
 	}
-	return &GenericExportResult{Status: "success", OutputPath: result}, nil
+
+	// Premiere may return success without writing a file on 24.x (QE exportFramePNG throws).
+	if _, statErr := os.Stat(params.OutputPath); statErr != nil {
+		if fbErr := e.exportFrameViaFFmpeg(ctx, params.OutputPath, 0); fbErr != nil {
+			return nil, fmt.Errorf("ExportFrame: premiere returned %q but file missing; ffmpeg fallback: %w", result, fbErr)
+		}
+		return &GenericExportResult{Status: "success", OutputPath: params.OutputPath}, nil
+	}
+	return &GenericExportResult{Status: "success", OutputPath: params.OutputPath}, nil
+}
+
+func (e *Engine) exportFrameWithFallback(ctx context.Context, params *ExportFrameParams, premiereErr error) (*GenericExportResult, error) {
+	if fbErr := e.exportFrameViaFFmpeg(ctx, params.OutputPath, 0); fbErr != nil {
+		return nil, fmt.Errorf("ExportFrame: %w; ffmpeg fallback: %v", premiereErr, fbErr)
+	}
+	return &GenericExportResult{Status: "success", OutputPath: params.OutputPath}, nil
 }
 
 // ExportAAF exports a sequence as an AAF file.

--- a/go-orchestrator/internal/orchestrator/frame_fallback.go
+++ b/go-orchestrator/internal/orchestrator/frame_fallback.go
@@ -1,0 +1,150 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+)
+
+type frameSourceInfo struct {
+	MediaPath string  `json:"mediaPath"`
+	Seconds   float64 `json:"seconds"`
+}
+
+// exportFrameViaFFmpeg extracts a single frame from the VOD under the playhead.
+// Used when Premiere 24.x QE exportFramePNG throws despite the method existing.
+func (e *Engine) exportFrameViaFFmpeg(ctx context.Context, outputPath string, seconds float64) error {
+	src, err := e.getFrameSourceAtPlayhead(ctx, seconds)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
+		return fmt.Errorf("create output dir: %w", err)
+	}
+	args := []string{
+		"-y",
+		"-ss", strconv.FormatFloat(src.Seconds, 'f', 3, 64),
+		"-i", src.MediaPath,
+		"-frames:v", "1",
+		"-update", "1",
+		outputPath,
+	}
+	cmd := exec.CommandContext(ctx, "ffmpeg", args...)
+	if out, runErr := cmd.CombinedOutput(); runErr != nil {
+		return fmt.Errorf("ffmpeg frame extract: %w (%s)", runErr, string(out))
+	}
+	if _, statErr := os.Stat(outputPath); statErr != nil {
+		return fmt.Errorf("ffmpeg did not create output file: %w", statErr)
+	}
+	return nil
+}
+
+func (e *Engine) captureFrameBase64ViaFFmpeg(ctx context.Context, seconds float64) (*FrameCaptureResult, error) {
+	tempFile := filepath.Join(os.TempDir(), fmt.Sprintf("mcp_frame_%d.png", os.Getpid()))
+	defer os.Remove(tempFile)
+
+	if err := e.exportFrameViaFFmpeg(ctx, tempFile, seconds); err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(tempFile)
+	if err != nil {
+		return nil, fmt.Errorf("read ffmpeg frame: %w", err)
+	}
+	return &FrameCaptureResult{
+		ImageBase64: base64.StdEncoding.EncodeToString(data),
+		Format:      "png",
+		Timecode:    seconds,
+	}, nil
+}
+
+func (e *Engine) getFrameSourceAtPlayhead(ctx context.Context, seconds float64) (*frameSourceInfo, error) {
+	script := fmt.Sprintf(`(function(){
+		var seq=app.project.activeSequence;
+		if(!seq) return JSON.stringify({error:"no active sequence"});
+		var pos=seq.getPlayerPosition();
+		var t=%f;
+		if(t>0){var tm=new Time();tm.seconds=t;seq.setPlayerPosition(tm.ticks);pos=seq.getPlayerPosition();}
+		var sec=pos.seconds;
+		for(var ti=0;ti<seq.videoTracks.numTracks;ti++){
+			var tr=seq.videoTracks[ti];
+			for(var ci=0;ci<tr.clips.numItems;ci++){
+				var c=tr.clips[ci];
+				if(c.start.seconds<=sec&&c.end.seconds>=sec){
+					var p=c.projectItem?c.projectItem.getMediaPath():"";
+					if(p){return JSON.stringify({mediaPath:p,seconds:sec});}
+				}
+			}
+		}
+		return JSON.stringify({error:"no media clip at playhead"});
+	})()`, seconds)
+
+	argsJSON, _ := json.Marshal(map[string]any{
+		"script":   script,
+		"validate": false,
+	})
+	raw, err := e.premiere.EvalCommand(ctx, "executeSecureScript", string(argsJSON))
+	if err != nil {
+		return nil, fmt.Errorf("get frame source: %w", err)
+	}
+
+	inner := unwrapEvalResult(raw)
+
+	var info frameSourceInfo
+	if err := json.Unmarshal([]byte(inner), &info); err != nil {
+		return nil, fmt.Errorf("parse frame source %q: %w", inner, err)
+	}
+	if info.MediaPath == "" {
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal([]byte(inner), &errResp) == nil && errResp.Error != "" {
+			return nil, fmt.Errorf("%s", errResp.Error)
+		}
+		return nil, fmt.Errorf("empty media path at playhead")
+	}
+	if info.Seconds <= 0 && seconds > 0 {
+		info.Seconds = seconds
+	}
+	return &info, nil
+}
+
+// unwrapEvalResult peels MCP/CEP JSON wrappers until we reach the inner payload string.
+func unwrapEvalResult(raw string) string {
+	inner := raw
+	for depth := 0; depth < 4; depth++ {
+		var wrapper struct {
+			Success bool            `json:"success"`
+			Data    json.RawMessage `json:"data"`
+			Result  string          `json:"result"`
+			Error   string          `json:"error"`
+		}
+		if err := json.Unmarshal([]byte(inner), &wrapper); err != nil {
+			break
+		}
+		if wrapper.Error != "" && !wrapper.Success {
+			return inner
+		}
+		if wrapper.Result != "" {
+			inner = wrapper.Result
+			continue
+		}
+		if len(wrapper.Data) > 0 {
+			var dataObj struct {
+				Result string `json:"result"`
+			}
+			if json.Unmarshal(wrapper.Data, &dataObj) == nil && dataObj.Result != "" {
+				inner = dataObj.Result
+				continue
+			}
+			inner = string(wrapper.Data)
+			continue
+		}
+		break
+	}
+	return inner
+}

--- a/go-orchestrator/internal/orchestrator/graphics_ops.go
+++ b/go-orchestrator/internal/orchestrator/graphics_ops.go
@@ -188,6 +188,32 @@ func (e *Engine) ExportCaptions(ctx context.Context, outputPath, format string) 
 	return &GenericResult{Status: "success", Message: result}, nil
 }
 
+// ExportSequenceTranscript writes transcript data for the active sequence.
+// Premiere 25.0+ with the UXP bridge reads Text-panel Speech-to-Text data;
+// otherwise ts-bridge falls back to caption tracks via CEP (Premiere 24.x).
+func (e *Engine) ExportSequenceTranscript(ctx context.Context, outputPath, format, speakerLabel string, includeAudioTracks bool) (*GenericResult, error) {
+	if outputPath == "" {
+		return nil, fmt.Errorf("ExportSequenceTranscript: outputPath is required")
+	}
+	if format == "" {
+		format = "prtranscript"
+	}
+	if speakerLabel == "" {
+		speakerLabel = "Unknown"
+	}
+	argsJSON, _ := json.Marshal(map[string]any{
+		"outputPath":         outputPath,
+		"format":             format,
+		"speakerLabel":       speakerLabel,
+		"includeAudioTracks": includeAudioTracks,
+	})
+	result, err := e.premiere.EvalCommand(ctx, "exportSequenceTranscript", string(argsJSON))
+	if err != nil {
+		return nil, fmt.Errorf("ExportSequenceTranscript: %w", err)
+	}
+	return &GenericResult{Status: "success", Message: result}, nil
+}
+
 func (e *Engine) StyleCaptions(ctx context.Context, trackIndex int, font string, size float64, color, bgColor, position string) (*GenericResult, error) {
 	argsJSON, _ := json.Marshal(map[string]any{
 		"trackIndex": trackIndex,

--- a/go-orchestrator/internal/orchestrator/interfaces.go
+++ b/go-orchestrator/internal/orchestrator/interfaces.go
@@ -290,6 +290,7 @@ type Orchestrator interface {
 	EditCaption(ctx context.Context, trackIndex, captionIndex int, text string) (*GenericResult, error)
 	DeleteCaption(ctx context.Context, trackIndex, captionIndex int) (*GenericResult, error)
 	ExportCaptions(ctx context.Context, outputPath, format string) (*GenericResult, error)
+	ExportSequenceTranscript(ctx context.Context, outputPath, format, speakerLabel string, includeAudioTracks bool) (*GenericResult, error)
 	StyleCaptions(ctx context.Context, trackIndex int, font string, size float64, color, bgColor, position string) (*GenericResult, error)
 	CreateColorMatte(ctx context.Context, name string, red, green, blue, width, height int) (*GenericResult, error)
 	PlaceColorMatte(ctx context.Context, projectItemIndex, trackIndex int, startTime, duration float64) (*GenericResult, error)

--- a/go-orchestrator/internal/orchestrator/sequence.go
+++ b/go-orchestrator/internal/orchestrator/sequence.go
@@ -419,6 +419,17 @@ func (e *Engine) GetSequenceMarkers(ctx context.Context) (*MarkersResult, error)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get sequence markers — make sure a sequence is active (try premiere_set_active_sequence): %w", err)
 	}
+	// ExtendScript returns _ok() => {"success":true,"data":{...}} ; unwrap data for Go structs.
+	type extendScriptEnvelope struct {
+		Data *MarkersResult `json:"data"`
+	}
+	var env extendScriptEnvelope
+	if err := json.Unmarshal([]byte(result), &env); err != nil {
+		return nil, fmt.Errorf("GetSequenceMarkers: could not parse response from Premiere Pro: %w", err)
+	}
+	if env.Data != nil {
+		return env.Data, nil
+	}
 	var out MarkersResult
 	if err := json.Unmarshal([]byte(result), &out); err != nil {
 		return nil, fmt.Errorf("GetSequenceMarkers: could not parse response from Premiere Pro: %w", err)

--- a/go-orchestrator/internal/orchestrator/sequence.go
+++ b/go-orchestrator/internal/orchestrator/sequence.go
@@ -158,7 +158,8 @@ func (e *Engine) GetSequenceList(ctx context.Context) (*SequenceListResult, erro
 		return nil, fmt.Errorf("failed to list sequences — open a project first with premiere_open_project: %w", err)
 	}
 	var out SequenceListResult
-	if err := json.Unmarshal([]byte(result), &out); err != nil {
+	payload := unwrapExtendScriptEnvelope(result)
+	if err := json.Unmarshal(payload, &out); err != nil {
 		return nil, fmt.Errorf("GetSequenceList: could not parse response from Premiere Pro: %w", err)
 	}
 	return &out, nil

--- a/go-orchestrator/internal/orchestrator/sequence.go
+++ b/go-orchestrator/internal/orchestrator/sequence.go
@@ -420,6 +420,17 @@ func (e *Engine) GetSequenceMarkers(ctx context.Context) (*MarkersResult, error)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get sequence markers — make sure a sequence is active (try premiere_set_active_sequence): %w", err)
 	}
+	// ExtendScript returns _ok() => {"success":true,"data":{...}} ; unwrap data for Go structs.
+	type extendScriptEnvelope struct {
+		Data *MarkersResult `json:"data"`
+	}
+	var env extendScriptEnvelope
+	if err := json.Unmarshal([]byte(result), &env); err != nil {
+		return nil, fmt.Errorf("GetSequenceMarkers: could not parse response from Premiere Pro: %w", err)
+	}
+	if env.Data != nil {
+		return env.Data, nil
+	}
 	var out MarkersResult
 	if err := json.Unmarshal([]byte(result), &out); err != nil {
 		return nil, fmt.Errorf("GetSequenceMarkers: could not parse response from Premiere Pro: %w", err)

--- a/scripts/cursor-mcp-launcher.cjs
+++ b/scripts/cursor-mcp-launcher.cjs
@@ -1,0 +1,105 @@
+/**
+ * MCP stdio root: owns ts-bridge (child) and go-orchestrator server.exe (child).
+ * stdin/stdout stay on server.exe via inherit → Cursor JSON-RPC unchanged.
+ * On server exit OR launcher signal, bridge is terminated so Premiere/CEP sees disconnect.
+ */
+
+"use strict";
+
+const { spawn } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const scriptsDir = __dirname;
+const repoRoot = path.resolve(scriptsDir, "..");
+const bridgeCwd = path.join(repoRoot, "ts-bridge");
+const bridgeEntry = path.join(bridgeCwd, "dist", "index.js");
+const serverExe = path.join(repoRoot, "go-orchestrator", "bin", "server.exe");
+
+function err(msg) {
+  console.error("[cursor-mcp-launcher]", msg);
+}
+
+if (!fs.existsSync(bridgeEntry)) {
+  err(`Missing ts-bridge build: ${bridgeEntry}`);
+  process.exit(1);
+}
+if (!fs.existsSync(serverExe)) {
+  err(`Missing go orchestrator binary: ${serverExe}`);
+  process.exit(1);
+}
+
+const launcherArgs = process.argv.slice(2);
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function killBridge(bridge) {
+  try {
+    if (bridge && bridge.pid && !bridge.killed) {
+      bridge.kill();
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
+(async function main() {
+  const bridge = spawn(process.execPath, [bridgeEntry], {
+    cwd: bridgeCwd,
+    stdio: "ignore",
+    windowsHide: true,
+    detached: false,
+  });
+
+  bridge.on("error", (e) => {
+    err(`Failed to start ts-bridge: ${e.message}`);
+    process.exit(1);
+  });
+
+  await sleep(2000);
+
+  const server = spawn(serverExe, launcherArgs, {
+    cwd: path.dirname(serverExe),
+    stdio: "inherit",
+    windowsHide: false,
+    detached: false,
+    env: process.env,
+  });
+
+  function shutdownFromParent() {
+    try {
+      if (server.pid && !server.killed) {
+        server.kill();
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
+  server.on("error", (e) => {
+    err(`Failed to start server.exe: ${e.message}`);
+    killBridge(bridge);
+    process.exit(1);
+  });
+
+  server.on("exit", (code) => {
+    killBridge(bridge);
+    process.exit(code === null ? 1 : code);
+  });
+
+  bridge.on("exit", (code, signal) => {
+    if (signal || (code !== 0 && code !== null)) {
+      err(`ts-bridge exited unexpectedly (code=${code}, signal=${signal})`);
+      shutdownFromParent();
+    }
+  });
+
+  process.on("SIGINT", shutdownFromParent);
+  process.on("SIGTERM", shutdownFromParent);
+  process.on("exit", () => killBridge(bridge));
+})().catch((e) => {
+  err(String(e && e.stack ? e.stack : e));
+  process.exit(1);
+});

--- a/scripts/cursor-mcp-launcher.cjs
+++ b/scripts/cursor-mcp-launcher.cjs
@@ -1,12 +1,15 @@
 /**
  * MCP stdio root: owns ts-bridge (child) and go-orchestrator server.exe (child).
  * stdin/stdout stay on server.exe via inherit → Cursor JSON-RPC unchanged.
- * On server exit OR launcher signal, bridge is terminated so Premiere/CEP sees disconnect.
+ *
+ * On Windows, Cursor often stops MCP by terminating the root process; children
+ * can survive (orphans). We use taskkill /T on shutdown paths and spawnSync on
+ * process 'exit' so the bridge is reliably torn down.
  */
 
 "use strict";
 
-const { spawn } = require("child_process");
+const { spawn, spawnSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 
@@ -15,6 +18,10 @@ const repoRoot = path.resolve(scriptsDir, "..");
 const bridgeCwd = path.join(repoRoot, "ts-bridge");
 const bridgeEntry = path.join(bridgeCwd, "dist", "index.js");
 const serverExe = path.join(repoRoot, "go-orchestrator", "bin", "server.exe");
+const isWin = process.platform === "win32";
+const taskkillExe = isWin
+  ? path.join(process.env.SystemRoot || "C:\\Windows", "System32", "taskkill.exe")
+  : null;
 
 function err(msg) {
   console.error("[cursor-mcp-launcher]", msg);
@@ -35,11 +42,47 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function killBridge(bridge) {
+/** Windows: kill pid and all descendants. No-op elsewhere. */
+function killProcessTreeWin(pid, sync) {
+  if (!isWin || !pid || !taskkillExe || !fs.existsSync(taskkillExe)) return;
+  const args = ["/PID", String(pid), "/T", "/F"];
   try {
-    if (bridge && bridge.pid && !bridge.killed) {
-      bridge.kill();
+    if (sync) {
+      spawnSync(taskkillExe, args, { stdio: "ignore", windowsHide: true });
+    } else {
+      const t = spawn(taskkillExe, args, {
+        stdio: "ignore",
+        windowsHide: true,
+        detached: true,
+      });
+      t.unref();
     }
+  } catch {
+    /* ignore */
+  }
+}
+
+function killBridge(bridge) {
+  if (!bridge || !bridge.pid) return;
+  if (isWin) {
+    killProcessTreeWin(bridge.pid, false);
+    return;
+  }
+  try {
+    if (!bridge.killed) bridge.kill();
+  } catch {
+    /* ignore */
+  }
+}
+
+function killServer(server) {
+  if (!server || !server.pid) return;
+  if (isWin) {
+    killProcessTreeWin(server.pid, false);
+    return;
+  }
+  try {
+    if (!server.killed) server.kill();
   } catch {
     /* ignore */
   }
@@ -68,14 +111,28 @@ function killBridge(bridge) {
     env: process.env,
   });
 
-  function shutdownFromParent() {
-    try {
-      if (server.pid && !server.killed) {
-        server.kill();
-      }
-    } catch {
-      /* ignore */
-    }
+  function cleanupAll() {
+    killServer(server);
+    killBridge(bridge);
+  }
+
+  function shutdownFromParentSignal() {
+    killServer(server);
+  }
+
+  if (isWin) {
+    process.on("exit", () => {
+      killProcessTreeWin(bridge.pid, true);
+      killProcessTreeWin(server.pid, true);
+    });
+  }
+
+  if (!process.stdin.isTTY) {
+    process.stdin.resume();
+    process.stdin.on("end", () => {
+      cleanupAll();
+      setTimeout(() => process.exit(0), 0);
+    });
   }
 
   server.on("error", (e) => {
@@ -92,13 +149,12 @@ function killBridge(bridge) {
   bridge.on("exit", (code, signal) => {
     if (signal || (code !== 0 && code !== null)) {
       err(`ts-bridge exited unexpectedly (code=${code}, signal=${signal})`);
-      shutdownFromParent();
+      shutdownFromParentSignal();
     }
   });
 
-  process.on("SIGINT", shutdownFromParent);
-  process.on("SIGTERM", shutdownFromParent);
-  process.on("exit", () => killBridge(bridge));
+  process.on("SIGINT", shutdownFromParentSignal);
+  process.on("SIGTERM", shutdownFromParentSignal);
 })().catch((e) => {
   err(String(e && e.stack ? e.stack : e));
   process.exit(1);

--- a/scripts/cursor-mcp-with-ts-bridge.cmd
+++ b/scripts/cursor-mcp-with-ts-bridge.cmd
@@ -1,0 +1,35 @@
+@echo off
+setlocal EnableExtensions
+REM Cursor MCP entry: TS gRPC bridge (50054) then Go orchestrator on stdio.
+REM Do NOT write to stdout except server.exe output (stdio is MCP JSON-RPC).
+REM Do NOT use "timeout" here — breaks when stdin is redirected (Cursor MCP).
+
+set "ROOT=%~dp0.."
+pushd "%ROOT%\ts-bridge" || exit /b 1
+if not exist "dist\index.js" (
+  echo [cursor-mcp] ERROR: Missing ts-bridge\dist\index.js. Run npm install and npm run build in ts-bridge. 1>&2
+  popd
+  exit /b 1
+)
+where node >nul 2>&1
+if errorlevel 1 (
+  echo [cursor-mcp] ERROR: node.exe not on PATH 1>&2
+  popd
+  exit /b 1
+)
+start "" /B node "dist\index.js"
+popd
+
+REM ~2s delay without timeout.exe (stdin-redirect-safe)
+ping 127.0.0.1 -n 3 >nul
+
+pushd "%ROOT%\go-orchestrator\bin" || exit /b 1
+if not exist "server.exe" (
+  echo [cursor-mcp] ERROR: go-orchestrator\bin\server.exe not found 1>&2
+  popd
+  exit /b 1
+)
+server.exe %*
+set "EXIT=%ERRORLEVEL%"
+popd
+exit /b %EXIT%

--- a/scripts/cursor-mcp-with-ts-bridge.cmd
+++ b/scripts/cursor-mcp-with-ts-bridge.cmd
@@ -1,35 +1,11 @@
 @echo off
 setlocal EnableExtensions
-REM Cursor MCP entry: TS gRPC bridge (50054) then Go orchestrator on stdio.
-REM Do NOT write to stdout except server.exe output (stdio is MCP JSON-RPC).
-REM Do NOT use "timeout" here — breaks when stdin is redirected (Cursor MCP).
+REM Delegates to Node so ts-bridge is a child process (not start /B). When MCP stops,
+REM launcher tears down bridge + server — Premiere CEP disconnects instead of a stale WS.
 
-set "ROOT=%~dp0.."
-pushd "%ROOT%\ts-bridge" || exit /b 1
-if not exist "dist\index.js" (
-  echo [cursor-mcp] ERROR: Missing ts-bridge\dist\index.js. Run npm install and npm run build in ts-bridge. 1>&2
-  popd
-  exit /b 1
-)
-where node >nul 2>&1
-if errorlevel 1 (
+where node >nul 2>&1 || (
   echo [cursor-mcp] ERROR: node.exe not on PATH 1>&2
-  popd
   exit /b 1
 )
-start "" /B node "dist\index.js"
-popd
-
-REM ~2s delay without timeout.exe (stdin-redirect-safe)
-ping 127.0.0.1 -n 3 >nul
-
-pushd "%ROOT%\go-orchestrator\bin" || exit /b 1
-if not exist "server.exe" (
-  echo [cursor-mcp] ERROR: go-orchestrator\bin\server.exe not found 1>&2
-  popd
-  exit /b 1
-)
-server.exe %*
-set "EXIT=%ERRORLEVEL%"
-popd
-exit /b %EXIT%
+node "%~dp0cursor-mcp-launcher.cjs" %*
+exit /b %ERRORLEVEL%

--- a/scripts/install-cep-panel-win.bat
+++ b/scripts/install-cep-panel-win.bat
@@ -20,6 +20,7 @@ REM Enable unsigned extensions
 REG ADD "HKCU\Software\Adobe\CSXS.11" /v PlayerDebugMode /t REG_SZ /d 1 /f
 REG ADD "HKCU\Software\Adobe\CSXS.12" /v PlayerDebugMode /t REG_SZ /d 1 /f
 REG ADD "HKCU\Software\Adobe\CSXS.13" /v PlayerDebugMode /t REG_SZ /d 1 /f
+REG ADD "HKCU\Software\Adobe\CSXS.14" /v PlayerDebugMode /t REG_SZ /d 1 /f
 
 echo.
 echo CEP panel installed. Restart Premiere Pro to load it.

--- a/scripts/install-uxp-panel-win.bat
+++ b/scripts/install-uxp-panel-win.bat
@@ -1,0 +1,30 @@
+@echo off
+REM Install UXP panel for PremierPro MCP transcript bridge on Windows.
+REM Requires Premiere Pro 25.0+ and UXP developer mode enabled in Preferences.
+
+set "PLUGIN_NAME=com.premierpro.mcp.uxpbridge"
+set "PLUGIN_DIR=%LOCALAPPDATA%\Adobe\UXP\Plugins\External\%PLUGIN_NAME%"
+set "SOURCE_DIR=%~dp0..\uxp-panel"
+
+echo Installing UXP transcript bridge panel...
+echo Source: %SOURCE_DIR%
+echo Target: %PLUGIN_DIR%
+
+if not exist "%SOURCE_DIR%\manifest.json" (
+    echo ERROR: uxp-panel source not found at %SOURCE_DIR%
+    exit /b 1
+)
+
+if exist "%PLUGIN_DIR%" rmdir /s /q "%PLUGIN_DIR%"
+mkdir "%PLUGIN_DIR%" 2>nul
+
+xcopy /E /I /Y "%SOURCE_DIR%\*" "%PLUGIN_DIR%\"
+
+echo.
+echo UXP panel copied.
+echo 1. In Premiere Pro: Preferences ^> UXP Plugins ^> Enable developer mode
+echo 2. Restart Premiere Pro
+echo 3. Open: Window ^> UXP Plugins ^> PremierPro MCP UXP Bridge
+echo 4. Confirm the panel shows Connected to ws://127.0.0.1:9802
+echo.
+echo Transcript export uses premiere_export_sequence_transcript (not caption tracks).

--- a/scripts/install-uxp-panel.sh
+++ b/scripts/install-uxp-panel.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Install UXP panel for PremierPro MCP transcript bridge (macOS).
+set -euo pipefail
+
+PLUGIN_ID="com.premierpro.mcp.uxpbridge"
+SOURCE_DIR="$(cd "$(dirname "$0")/../uxp-panel" && pwd)"
+TARGET_DIR="${HOME}/Library/Application Support/Adobe/UXP/Plugins/External/${PLUGIN_ID}"
+
+echo "Installing UXP transcript bridge panel..."
+echo "Source: ${SOURCE_DIR}"
+echo "Target: ${TARGET_DIR}"
+
+if [[ ! -f "${SOURCE_DIR}/manifest.json" ]]; then
+  echo "ERROR: uxp-panel source not found" >&2
+  exit 1
+fi
+
+rm -rf "${TARGET_DIR}"
+mkdir -p "${TARGET_DIR}"
+cp -R "${SOURCE_DIR}/." "${TARGET_DIR}/"
+
+echo ""
+echo "UXP panel installed."
+echo "1. Enable UXP developer mode in Premiere Pro Preferences"
+echo "2. Restart Premiere Pro"
+echo "3. Open Window > UXP Plugins > PremierPro MCP UXP Bridge"
+echo "4. Confirm Connected to ws://127.0.0.1:9802"

--- a/ts-bridge/src/bridge/cep-bridge.ts
+++ b/ts-bridge/src/bridge/cep-bridge.ts
@@ -97,45 +97,61 @@ const DEFAULT_RECONNECT_MAX_MS = 30_000;
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const PONG_TIMEOUT_MS = 5_000;
 
-/**
- * ExtendScript helpers use `_ok({ ... })` → JSON `{ success: true, data: payload }`.
- * The CEP panel forwards that whole object as the WebSocket `result`. Unwrap so
- * gRPC serializers see proto-shaped fields (camelCase).
- */
-function unwrapCepEnvelope(raw: unknown): Record<string, unknown> {
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-    return {};
-  }
-  const o = raw as Record<string, unknown>;
-  if (
-    o["success"] === true &&
-    o["data"] !== undefined &&
-    o["data"] !== null &&
-    typeof o["data"] === "object" &&
-    !Array.isArray(o["data"])
-  ) {
-    return o["data"] as Record<string, unknown>;
-  }
-  return o;
-}
+/** Map CEP WebSocket ping payload to gRPC {@link PingResult}. Handles PP24 + PP25 envelope shapes. */
+function normalizeCepPingResult(raw: unknown): PingResult {
+  const fallback: PingResult = {
+    premiereRunning: false,
+    premiereVersion: "",
+    projectOpen: false,
+    bridgeMode: "cep",
+  };
 
-function normalizePingPayload(payload: Record<string, unknown>): PingResult {
+  if (raw === null || raw === undefined || typeof raw !== "object") {
+    return fallback;
+  }
+
+  const o = raw as Record<string, unknown>;
+  const data = o["data"];
+  let inner: Record<string, unknown> | undefined;
+  if (typeof data === "object" && data !== null) {
+    inner = data as Record<string, unknown>;
+  } else if ("premiere_running" in o || "premiereRunning" in o) {
+    inner = o;
+  }
+
+  if (!inner) {
+    return fallback;
+  }
+
   const running =
-    payload["premiereRunning"] === true || payload["premiere_running"] === true;
-  const ver =
-    (typeof payload["premiereVersion"] === "string" && payload["premiereVersion"]) ||
-    (typeof payload["premiere_version"] === "string" && payload["premiere_version"]) ||
-    "";
-  const projOpen =
-    payload["projectOpen"] === true || payload["project_open"] === true;
+    typeof inner["premiereRunning"] === "boolean"
+      ? inner["premiereRunning"]
+      : typeof inner["premiere_running"] === "boolean"
+        ? inner["premiere_running"]
+        : false;
+  const version =
+    typeof inner["premiereVersion"] === "string"
+      ? inner["premiereVersion"]
+      : typeof inner["premiere_version"] === "string"
+        ? inner["premiere_version"]
+        : "";
+  const open =
+    typeof inner["projectOpen"] === "boolean"
+      ? inner["projectOpen"]
+      : typeof inner["project_open"] === "boolean"
+        ? inner["project_open"]
+        : false;
   const mode =
-    (typeof payload["bridgeMode"] === "string" && payload["bridgeMode"]) ||
-    (typeof payload["bridge_mode"] === "string" && payload["bridge_mode"]) ||
-    "cep";
+    typeof inner["bridgeMode"] === "string"
+      ? inner["bridgeMode"]
+      : typeof inner["bridge_mode"] === "string"
+        ? inner["bridge_mode"]
+        : "cep";
+
   return {
     premiereRunning: running,
-    premiereVersion: ver,
-    projectOpen: projOpen,
+    premiereVersion: version,
+    projectOpen: open,
     bridgeMode: mode,
   };
 }
@@ -469,8 +485,7 @@ export class CepBridge implements PremiereBridge {
           bridgeMode: "cep",
         };
       }
-      const payload = unwrapCepEnvelope(raw);
-      return normalizePingPayload(payload);
+      return normalizeCepPingResult(raw);
     } catch {
       return {
         premiereRunning: false,

--- a/ts-bridge/src/bridge/cep-bridge.ts
+++ b/ts-bridge/src/bridge/cep-bridge.ts
@@ -101,6 +101,65 @@ const PONG_TIMEOUT_MS = 5_000;
 // Implementation
 // ---------------------------------------------------------------------------
 
+/** Map CEP WebSocket ping payload to gRPC {@link PingResult}. */
+function normalizeCepPingResult(raw: unknown): PingResult {
+  const fallback: PingResult = {
+    premiereRunning: false,
+    premiereVersion: "",
+    projectOpen: false,
+    bridgeMode: "cep",
+  };
+
+  if (raw === null || raw === undefined || typeof raw !== "object") {
+    return fallback;
+  }
+
+  const o = raw as Record<string, unknown>;
+  const data = o["data"];
+  let inner: Record<string, unknown> | undefined;
+  if (typeof data === "object" && data !== null) {
+    inner = data as Record<string, unknown>;
+  } else if ("premiere_running" in o || "premiereRunning" in o) {
+    inner = o;
+  }
+
+  if (!inner) {
+    return fallback;
+  }
+
+  const running =
+    typeof inner["premiereRunning"] === "boolean"
+      ? inner["premiereRunning"]
+      : typeof inner["premiere_running"] === "boolean"
+        ? inner["premiere_running"]
+        : false;
+  const version =
+    typeof inner["premiereVersion"] === "string"
+      ? inner["premiereVersion"]
+      : typeof inner["premiere_version"] === "string"
+        ? inner["premiere_version"]
+        : "";
+  const open =
+    typeof inner["projectOpen"] === "boolean"
+      ? inner["projectOpen"]
+      : typeof inner["project_open"] === "boolean"
+        ? inner["project_open"]
+        : false;
+  const mode =
+    typeof inner["bridgeMode"] === "string"
+      ? inner["bridgeMode"]
+      : typeof inner["bridge_mode"] === "string"
+        ? inner["bridge_mode"]
+        : "cep";
+
+  return {
+    premiereRunning: running,
+    premiereVersion: version,
+    projectOpen: open,
+    bridgeMode: mode,
+  };
+}
+
 export class CepBridge implements PremiereBridge {
   private readonly log: Logger;
   private readonly wsUrl: string;
@@ -412,7 +471,8 @@ export class CepBridge implements PremiereBridge {
 
   async ping(): Promise<PingResult> {
     try {
-      return await this.send<PingResult>("ping", {});
+      const raw = await this.send<unknown>("ping", {});
+      return normalizeCepPingResult(raw);
     } catch {
       return {
         premiereRunning: false,

--- a/ts-bridge/src/bridge/cep-bridge.ts
+++ b/ts-bridge/src/bridge/cep-bridge.ts
@@ -97,6 +97,49 @@ const DEFAULT_RECONNECT_MAX_MS = 30_000;
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const PONG_TIMEOUT_MS = 5_000;
 
+/**
+ * ExtendScript helpers use `_ok({ ... })` → JSON `{ success: true, data: payload }`.
+ * The CEP panel forwards that whole object as the WebSocket `result`. Unwrap so
+ * gRPC serializers see proto-shaped fields (camelCase).
+ */
+function unwrapCepEnvelope(raw: unknown): Record<string, unknown> {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return {};
+  }
+  const o = raw as Record<string, unknown>;
+  if (
+    o["success"] === true &&
+    o["data"] !== undefined &&
+    o["data"] !== null &&
+    typeof o["data"] === "object" &&
+    !Array.isArray(o["data"])
+  ) {
+    return o["data"] as Record<string, unknown>;
+  }
+  return o;
+}
+
+function normalizePingPayload(payload: Record<string, unknown>): PingResult {
+  const running =
+    payload["premiereRunning"] === true || payload["premiere_running"] === true;
+  const ver =
+    (typeof payload["premiereVersion"] === "string" && payload["premiereVersion"]) ||
+    (typeof payload["premiere_version"] === "string" && payload["premiere_version"]) ||
+    "";
+  const projOpen =
+    payload["projectOpen"] === true || payload["project_open"] === true;
+  const mode =
+    (typeof payload["bridgeMode"] === "string" && payload["bridgeMode"]) ||
+    (typeof payload["bridge_mode"] === "string" && payload["bridge_mode"]) ||
+    "cep";
+  return {
+    premiereRunning: running,
+    premiereVersion: ver,
+    projectOpen: projOpen,
+    bridgeMode: mode,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Implementation
 // ---------------------------------------------------------------------------
@@ -412,7 +455,22 @@ export class CepBridge implements PremiereBridge {
 
   async ping(): Promise<PingResult> {
     try {
-      return await this.send<PingResult>("ping", {});
+      const raw = await this.send<unknown>("ping", {});
+      if (
+        raw &&
+        typeof raw === "object" &&
+        !Array.isArray(raw) &&
+        (raw as Record<string, unknown>)["success"] === false
+      ) {
+        return {
+          premiereRunning: false,
+          premiereVersion: "",
+          projectOpen: false,
+          bridgeMode: "cep",
+        };
+      }
+      const payload = unwrapCepEnvelope(raw);
+      return normalizePingPayload(payload);
     } catch {
       return {
         premiereRunning: false,

--- a/ts-bridge/src/bridge/cep-bridge.ts
+++ b/ts-bridge/src/bridge/cep-bridge.ts
@@ -225,8 +225,9 @@ export class CepBridge implements PremiereBridge {
           ws.terminate();
           this.log.warn(
             `Connection to CEP panel at ${this.wsUrl} timed out. ` +
-              "Bridge will operate in disconnected mode.",
+              "Bridge will operate in disconnected mode until CEP is available.",
           );
+          this.scheduleReconnect();
           resolve();
         }
       }, this.commandTimeoutMs);
@@ -283,8 +284,9 @@ export class CepBridge implements PremiereBridge {
           clearTimeout(connectionTimeout);
           this.log.warn(
             `Could not connect to CEP panel: ${err.message}. ` +
-              "Bridge will operate in disconnected mode.",
+              "Bridge will operate in disconnected mode until CEP is available.",
           );
+          this.scheduleReconnect();
           resolve();
         } else {
           this.log.error(`WebSocket error: ${err.message}`);

--- a/ts-bridge/src/compat/premiere-version.ts
+++ b/ts-bridge/src/compat/premiere-version.ts
@@ -1,0 +1,33 @@
+/**
+ * Parse `app.version` from Premiere (via ping / health) for PP24 vs PP25 code paths.
+ */
+
+export interface ParsedPremiereVersion {
+  major: number;
+  minor: number;
+}
+
+/** Parses Adobe-style version strings: "25.0", "24.6.2", "25". */
+export function parsePremiereVersionString(version: string): ParsedPremiereVersion | null {
+  const v = version.trim();
+  if (!v) return null;
+  const m = /^(\d+)(?:\.(\d+))?/.exec(v);
+  if (!m) return null;
+  return {
+    major: parseInt(m[1], 10),
+    minor: m[2] !== undefined ? parseInt(m[2], 10) : 0,
+  };
+}
+
+/** True if version >= minMajor.minMinor (major beats minor). */
+export function premiereVersionAtLeast(
+  version: string,
+  minMajor: number,
+  minMinor = 0,
+): boolean {
+  const p = parsePremiereVersionString(version);
+  if (!p) return false;
+  if (p.major > minMajor) return true;
+  if (p.major < minMajor) return false;
+  return p.minor >= minMinor;
+}

--- a/ts-bridge/src/config.ts
+++ b/ts-bridge/src/config.ts
@@ -26,6 +26,12 @@ export interface BridgeConfig {
   /** WebSocket port for CEP panel communication (only used in cep mode). */
   cepWsPort: number;
 
+  /** WebSocket port for UXP panel transcript bridge (Premiere 25.0+). */
+  uxpWsPort: number;
+
+  /** Timeout for UXP transcript commands (ms). */
+  uxpCommandTimeoutMs: number;
+
   /** gRPC server host/bind address. */
   grpcHost: string;
 }
@@ -52,7 +58,9 @@ const VALID_LOG_LEVELS: ReadonlySet<string> = new Set<LogLevel>([
  * | PREMIERE_PATH         | /Applications/Adobe Premiere Pro 2025/...             |
  * | BRIDGE_MODE           | cep                                                  |
  * | BRIDGE_LOG_LEVEL      | info                                                 |
- * | BRIDGE_CEP_WS_PORT    | 8089                                                 |
+ * | BRIDGE_CEP_WS_PORT    | 9801                                                 |
+ * | BRIDGE_UXP_WS_PORT    | 9802                                                 |
+ * | BRIDGE_UXP_CMD_TIMEOUT_MS | 120000                                           |
  */
 export function loadConfig(): BridgeConfig {
   const rawMode = process.env["BRIDGE_MODE"] ?? "cep";
@@ -78,7 +86,22 @@ export function loadConfig(): BridgeConfig {
     bridgeMode: rawMode as BridgeMode,
     logLevel: rawLogLevel as LogLevel,
     cepWsPort: parsePort("BRIDGE_CEP_WS_PORT", 9801),
+    uxpWsPort: parsePort("BRIDGE_UXP_WS_PORT", 9802),
+    uxpCommandTimeoutMs: parsePositiveInt("BRIDGE_UXP_CMD_TIMEOUT_MS", 120_000),
   };
+}
+
+function parsePositiveInt(envKey: string, fallback: number): number {
+  const raw = process.env[envKey];
+  if (raw === undefined) return fallback;
+
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed) || parsed < 1) {
+    throw new Error(
+      `Invalid ${envKey} "${raw}". Must be a positive integer.`,
+    );
+  }
+  return parsed;
 }
 
 function parsePort(envKey: string, fallback: number): number {

--- a/ts-bridge/src/grpc/handlers.ts
+++ b/ts-bridge/src/grpc/handlers.ts
@@ -12,6 +12,58 @@
 
 import type { Logger } from "winston";
 import type { PremiereBridge } from "../bridge/interface.js";
+import { getUxpWsServer } from "../uxp/uxp-ws-server.js";
+
+async function exportSequenceTranscriptViaCep(
+  bridge: PremiereBridge,
+  params: Record<string, unknown>,
+  logger: Logger,
+): Promise<{
+  resultJson: string;
+  isError: boolean;
+  errorMessage: string;
+}> {
+  logger.info("Using caption-track transcript fallback (CEP/ExtendScript)");
+
+  const result = await bridge.evalCommand(
+    "exportSequenceTranscript",
+    JSON.stringify(params),
+  );
+
+  if (result.isError) {
+    return {
+      resultJson: "",
+      isError: true,
+      errorMessage: result.errorMessage,
+    };
+  }
+
+  let parsed: Record<string, unknown> = {};
+  try {
+    parsed = JSON.parse(result.resultJson) as Record<string, unknown>;
+  } catch {
+    return {
+      resultJson: result.resultJson,
+      isError: false,
+      errorMessage: "",
+    };
+  }
+
+  if (parsed.success === false) {
+    return {
+      resultJson: result.resultJson,
+      isError: true,
+      errorMessage: String(parsed.error ?? "Caption transcript export failed"),
+    };
+  }
+
+  const data = (parsed.data ?? parsed) as Record<string, unknown>;
+  return {
+    resultJson: JSON.stringify(data),
+    isError: false,
+    errorMessage: "",
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Inline request / response types (mirrors proto messages)
@@ -513,6 +565,51 @@ export function createHandlers(
       logger.info("gRPC call: EvalCommand", {
         functionName: request.functionName,
       });
+
+      if (request.functionName === "exportSequenceTranscript") {
+        let params: Record<string, unknown> = {};
+        try {
+          params = JSON.parse(request.argsJson || "{}") as Record<
+            string,
+            unknown
+          >;
+        } catch (err) {
+          return {
+            resultJson: "",
+            isError: true,
+            errorMessage: `Invalid exportSequenceTranscript args JSON: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          };
+        }
+
+        const uxp = getUxpWsServer();
+        if (uxp?.isConnected) {
+          try {
+            const uxpResult = await uxp.sendCommand(
+              "exportSequenceTranscript",
+              params,
+            );
+            if (uxpResult.success) {
+              return {
+                resultJson: JSON.stringify(uxpResult.result ?? uxpResult),
+                isError: false,
+                errorMessage: "",
+              };
+            }
+            logger.info("UXP transcript export failed; trying caption fallback", {
+              error: uxpResult.error,
+            });
+          } catch (err) {
+            logger.warn("UXP transcript export error; trying caption fallback", {
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+
+        return exportSequenceTranscriptViaCep(bridge, params, logger);
+      }
+
       const result = await bridge.evalCommand(
         request.functionName,
         request.argsJson,

--- a/ts-bridge/src/index.ts
+++ b/ts-bridge/src/index.ts
@@ -9,6 +9,7 @@ import { createLogger, format, transports } from "winston";
 import { loadConfig } from "./config.js";
 import { createBridge } from "./bridge/factory.js";
 import { createGrpcServer } from "./grpc/server.js";
+import { setUxpWsServer, UxpWsServer } from "./uxp/uxp-ws-server.js";
 
 async function main(): Promise<void> {
   // ── Configuration ──────────────────────────────────────────────────────
@@ -44,6 +45,17 @@ async function main(): Promise<void> {
   await bridge.connect();
   logger.info(`Bridge initialized in "${config.bridgeMode}" mode`);
 
+  // ── UXP transcript bridge (Premiere 25.0+ Text panel API) ─────────────
+  const uxpServer = new UxpWsServer(config, logger);
+  setUxpWsServer(uxpServer);
+  try {
+    await uxpServer.start();
+  } catch (err) {
+    logger.warn("UXP WebSocket server failed to start; transcript export unavailable", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
   // ── gRPC server ────────────────────────────────────────────────────────
   const grpcServer = await createGrpcServer(config, bridge, logger);
   await grpcServer.start();
@@ -58,6 +70,7 @@ async function main(): Promise<void> {
 
     try {
       await grpcServer.stop();
+      await uxpServer.stop();
       await bridge.disconnect();
       logger.info("Shutdown complete");
     } catch (err) {

--- a/ts-bridge/src/uxp/uxp-ws-server.ts
+++ b/ts-bridge/src/uxp/uxp-ws-server.ts
@@ -1,0 +1,193 @@
+/**
+ * WebSocket server for the PremierPro MCP UXP panel.
+ *
+ * The UXP panel connects as a client. Transcript operations (Text panel data)
+ * are routed here when available. ExtendScript caption-track fallback covers
+ * Premiere 24.x when UXP is unavailable.
+ */
+
+import { randomUUID } from "node:crypto";
+import WebSocket, { WebSocketServer } from "ws";
+import type { Logger } from "winston";
+
+import type { BridgeConfig } from "../config.js";
+
+export interface UxpCommandResult {
+  success: boolean;
+  result?: unknown;
+  error?: string;
+}
+
+interface PendingRequest {
+  resolve: (value: UxpCommandResult) => void;
+  reject: (reason: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+export class UxpWsServer {
+  private wss: WebSocketServer | null = null;
+  private client: WebSocket | null = null;
+  private readonly pending = new Map<string, PendingRequest>();
+  private readonly commandTimeoutMs: number;
+
+  constructor(
+    private readonly config: BridgeConfig,
+    private readonly logger: Logger,
+  ) {
+    this.commandTimeoutMs = config.uxpCommandTimeoutMs;
+  }
+
+  get isConnected(): boolean {
+    return this.client !== null && this.client.readyState === WebSocket.OPEN;
+  }
+
+  async start(): Promise<void> {
+    if (this.wss) return;
+
+    const port = this.config.uxpWsPort;
+    this.wss = new WebSocketServer({ host: "127.0.0.1", port });
+
+    await new Promise<void>((resolve, reject) => {
+      this.wss!.once("listening", () => resolve());
+      this.wss!.once("error", (err) => reject(err));
+    });
+
+    this.wss.on("connection", (socket, req) => {
+      const remote = req.socket.remoteAddress ?? "unknown";
+      this.logger.info("UXP panel connected", { remote });
+
+      if (this.client && this.client.readyState === WebSocket.OPEN) {
+        this.logger.warn("Replacing existing UXP panel connection");
+        try {
+          this.client.close(1000, "replaced");
+        } catch {
+          /* ignore */
+        }
+      }
+
+      this.client = socket;
+
+      socket.on("message", (data) => {
+        this.handleMessage(data.toString());
+      });
+
+      socket.on("close", () => {
+        if (this.client === socket) {
+          this.client = null;
+          this.logger.warn("UXP panel disconnected");
+        }
+      });
+
+      socket.on("error", (err) => {
+        this.logger.error("UXP panel socket error", { error: err.message });
+      });
+    });
+
+    this.logger.info("UXP WebSocket server listening", { port });
+  }
+
+  async stop(): Promise<void> {
+    for (const [, pending] of this.pending) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error("UXP WebSocket server shutting down"));
+    }
+    this.pending.clear();
+
+    if (this.client) {
+      try {
+        this.client.close(1000);
+      } catch {
+        /* ignore */
+      }
+      this.client = null;
+    }
+
+    if (this.wss) {
+      await new Promise<void>((resolve) => {
+        this.wss!.close(() => resolve());
+      });
+      this.wss = null;
+    }
+  }
+
+  async sendCommand(
+    action: string,
+    params: Record<string, unknown> = {},
+  ): Promise<UxpCommandResult> {
+    if (!this.isConnected || !this.client) {
+      return {
+        success: false,
+        error:
+          "UXP bridge panel is not connected. Open Window > UXP Plugins > PremierPro MCP UXP Bridge in Premiere Pro (requires Premiere 25.0+).",
+      };
+    }
+
+    const requestId = randomUUID();
+    const payload = JSON.stringify({ requestId, action, params });
+
+    return new Promise<UxpCommandResult>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(requestId);
+        reject(
+          new Error(
+            `UXP command "${action}" timed out after ${this.commandTimeoutMs}ms`,
+          ),
+        );
+      }, this.commandTimeoutMs);
+
+      this.pending.set(requestId, { resolve, reject, timer });
+
+      try {
+        this.client!.send(payload);
+      } catch (err) {
+        clearTimeout(timer);
+        this.pending.delete(requestId);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+  }
+
+  private handleMessage(raw: string): void {
+    let message: Record<string, unknown>;
+    try {
+      message = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      this.logger.warn("UXP panel sent non-JSON message");
+      return;
+    }
+
+    if (message["type"] === "hello") {
+      this.logger.info("UXP panel hello", {
+        role: message["role"],
+        version: message["version"],
+      });
+      return;
+    }
+
+    const requestId = message["requestId"];
+    if (typeof requestId !== "string") return;
+
+    const pending = this.pending.get(requestId);
+    if (!pending) return;
+
+    clearTimeout(pending.timer);
+    this.pending.delete(requestId);
+
+    pending.resolve({
+      success: message["success"] === true,
+      result: message["result"],
+      error:
+        typeof message["error"] === "string" ? message["error"] : undefined,
+    });
+  }
+}
+
+let singleton: UxpWsServer | null = null;
+
+export function setUxpWsServer(server: UxpWsServer): void {
+  singleton = server;
+}
+
+export function getUxpWsServer(): UxpWsServer | null {
+  return singleton;
+}

--- a/uxp-panel/index.html
+++ b/uxp-panel/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>PremierPro MCP UXP Bridge</title>
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      font-size: 12px;
+      margin: 12px;
+      color: #e8e8e8;
+      background: #1e1e1e;
+    }
+    h1 { font-size: 14px; margin: 0 0 8px; }
+    #status { margin-bottom: 8px; }
+    .ok { color: #7dcea0; }
+    .warn { color: #f5b041; }
+    .err { color: #ec7063; }
+    #log {
+      white-space: pre-wrap;
+      font-family: Consolas, monospace;
+      font-size: 11px;
+      max-height: 240px;
+      overflow: auto;
+      border: 1px solid #333;
+      padding: 8px;
+      background: #111;
+    }
+    label { display: block; margin-top: 8px; }
+    input { width: 100%; box-sizing: border-box; margin-top: 4px; }
+    button { margin-top: 8px; margin-right: 6px; }
+  </style>
+</head>
+<body>
+  <h1>PremierPro MCP UXP Bridge</h1>
+  <div id="status" class="warn">Disconnected</div>
+  <label>
+    MCP WebSocket URL
+    <input id="ws-url" type="text" value="ws://127.0.0.1:9802" />
+  </label>
+  <button id="btn-reconnect">Reconnect</button>
+  <button id="btn-clear">Clear log</button>
+  <div id="log"></div>
+  <script src="src/main.js"></script>
+</body>
+</html>

--- a/uxp-panel/manifest.json
+++ b/uxp-panel/manifest.json
@@ -1,0 +1,30 @@
+{
+  "id": "com.premierpro.mcp.uxpbridge",
+  "name": "PremierPro MCP UXP Bridge",
+  "version": "1.0.0",
+  "host": {
+    "app": "premierepro",
+    "minVersion": "25.0.0"
+  },
+  "type": "panel",
+  "uiEntry": {
+    "type": "panel",
+    "file": "index.html"
+  },
+  "entrypoints": [
+    {
+      "type": "panel",
+      "id": "premierpro-mcp-uxp-bridge",
+      "label": { "default": "PremierPro MCP UXP Bridge" },
+      "file": "index.html"
+    }
+  ],
+  "manifestVersion": 5,
+  "requiredPermissions": {
+    "allowCodeGenerationFromStrings": true,
+    "network": {
+      "domains": ["127.0.0.1", "localhost"]
+    },
+    "localFileSystem": "fullAccess"
+  }
+}

--- a/uxp-panel/src/main.js
+++ b/uxp-panel/src/main.js
@@ -1,0 +1,493 @@
+/**
+ * PremierPro MCP UXP Bridge
+ *
+ * Connects to the ts-bridge WebSocket server and serves transcript operations
+ * via Premiere Pro's UXP Transcript API (Text panel data, not caption tracks).
+ */
+
+(function () {
+  "use strict";
+
+  const ppro = require("premierepro");
+  const uxp = require("uxp");
+  const storage = uxp.storage;
+  const fs = storage.localFileSystem;
+
+  const VERSION = "1.0.0";
+  const DEFAULT_WS_URL = "ws://127.0.0.1:9802";
+  const RECONNECT_MS = 3000;
+
+  let ws = null;
+  let reconnectTimer = null;
+  let wsUrl = DEFAULT_WS_URL;
+
+  const statusEl = document.getElementById("status");
+  const logEl = document.getElementById("log");
+  const wsUrlInput = document.getElementById("ws-url");
+  const btnReconnect = document.getElementById("btn-reconnect");
+  const btnClear = document.getElementById("btn-clear");
+
+  function log(message, level) {
+    const line = "[" + new Date().toISOString() + "] " + message;
+    if (logEl) {
+      logEl.textContent += line + "\n";
+      logEl.scrollTop = logEl.scrollHeight;
+    }
+    console.log("[uxp-bridge][" + (level || "info") + "] " + message);
+  }
+
+  function setStatus(text, cls) {
+    if (statusEl) {
+      statusEl.textContent = text;
+      statusEl.className = cls || "warn";
+    }
+  }
+
+  function loadWsUrl() {
+    try {
+      const saved = localStorage.getItem("premierpro_mcp_uxp_ws_url");
+      if (saved) {
+        wsUrl = saved;
+        if (wsUrlInput) wsUrlInput.value = saved;
+      }
+    } catch (e) { /* ignore */ }
+  }
+
+  function saveWsUrl(url) {
+    wsUrl = url;
+    try { localStorage.setItem("premierpro_mcp_uxp_ws_url", url); } catch (e) { /* ignore */ }
+  }
+
+  function pad2(n) { return n < 10 ? "0" + n : String(n); }
+
+  function secondsToTimecode(seconds, fps) {
+    const rate = fps > 0 ? fps : 30;
+    const totalFrames = Math.max(0, Math.round(seconds * rate));
+    const h = Math.floor(totalFrames / (rate * 3600));
+    const m = Math.floor((totalFrames % (rate * 3600)) / (rate * 60));
+    const s = Math.floor((totalFrames % (rate * 60)) / rate);
+    const f = totalFrames % rate;
+    return pad2(h) + ":" + pad2(m) + ":" + pad2(s) + ":" + pad2(f);
+  }
+
+  function toFileUrl(filePath) {
+    const norm = String(filePath || "").replace(/\\/g, "/");
+    if (/^[A-Za-z]:\//.test(norm)) return "file:/" + norm;
+    if (norm.startsWith("/")) return "file://" + norm;
+    return "file://" + norm;
+  }
+
+  async function writeTextFile(outputPath, content) {
+    const url = toFileUrl(outputPath);
+    let entry;
+    try {
+      entry = await fs.getEntryWithUrl(url);
+    } catch (e) {
+      const lastSlash = Math.max(outputPath.lastIndexOf("/"), outputPath.lastIndexOf("\\"));
+      const dirPath = lastSlash > 0 ? outputPath.substring(0, lastSlash) : outputPath;
+      const fileName = lastSlash > 0 ? outputPath.substring(lastSlash + 1) : outputPath;
+      const dirUrl = toFileUrl(dirPath);
+      const dir = await fs.getEntryWithUrl(dirUrl);
+      entry = await dir.createFile(fileName, { overwrite: true });
+    }
+    await entry.write(content, { format: storage.formats.utf8 });
+  }
+
+  function segmentText(words) {
+    if (!words || !words.length) return "";
+    let out = "";
+    for (let i = 0; i < words.length; i++) {
+      const w = words[i];
+      const t = w && w.text ? String(w.text) : "";
+      if (!t) continue;
+      if (w.type === "punctuation" && out.length > 0) {
+        out += t;
+      } else if (out.length === 0) {
+        out = t;
+      } else {
+        out += " " + t;
+      }
+    }
+    return out.trim();
+  }
+
+  function speakerNameForSegment(segment, speakers, fallback) {
+    if (!segment || !segment.speaker || !speakers || !speakers.length) return fallback;
+    for (let i = 0; i < speakers.length; i++) {
+      if (speakers[i].id === segment.speaker) {
+        return speakers[i].name || fallback;
+      }
+    }
+    return fallback;
+  }
+
+  async function getSequenceFps(sequence) {
+    try {
+      const settings = await sequence.getSettings();
+      const frameRate = settings.getVideoFrameRate();
+      const value = frameRate && frameRate.value ? Number(frameRate.value) : 0;
+      return value > 0 ? value : 30;
+    } catch (e) {
+      return 30;
+    }
+  }
+
+  async function tickSeconds(tickTime) {
+    if (!tickTime) return 0;
+    if (typeof tickTime.seconds === "number") return tickTime.seconds;
+    if (typeof tickTime.getSeconds === "function") {
+      const s = await tickTime.getSeconds();
+      return typeof s === "number" ? s : 0;
+    }
+    return 0;
+  }
+
+  async function collectFromTrackItem(trackItem, segments, stats, fps) {
+    if (!trackItem) return;
+
+    let projectItem;
+    try {
+      projectItem = await trackItem.getProjectItem();
+    } catch (e) {
+      stats.errors.push("getProjectItem failed: " + e.message);
+      return;
+    }
+    if (!projectItem) return;
+
+    const clipProjectItem = ppro.ClipProjectItem.cast(projectItem);
+    if (!clipProjectItem) return;
+
+    let hasTranscript = false;
+    try {
+      hasTranscript = ppro.Transcript.hasTranscript(clipProjectItem);
+    } catch (e) {
+      stats.errors.push("hasTranscript failed for " + (projectItem.name || "clip") + ": " + e.message);
+      return;
+    }
+
+    if (!hasTranscript) {
+      stats.clipsWithoutTranscript++;
+      return;
+    }
+
+    let jsonStr;
+    try {
+      jsonStr = await ppro.Transcript.exportToJSON(clipProjectItem);
+    } catch (e) {
+      stats.errors.push("exportToJSON failed for " + (projectItem.name || "clip") + ": " + e.message);
+      return;
+    }
+
+    let transcript;
+    try {
+      transcript = typeof jsonStr === "string" ? JSON.parse(jsonStr) : jsonStr;
+    } catch (e) {
+      stats.errors.push("transcript JSON parse failed: " + e.message);
+      return;
+    }
+
+    const seqStart = await tickSeconds(await trackItem.getStartTime());
+    const inPoint = await tickSeconds(await trackItem.getInPoint());
+
+    const speakers = transcript.speakers || [];
+    const segs = transcript.segments || [];
+    stats.clipsWithTranscript++;
+
+    for (let i = 0; i < segs.length; i++) {
+      const seg = segs[i];
+      const relStart = typeof seg.start === "number" ? seg.start : 0;
+      const relDuration = typeof seg.duration === "number" ? seg.duration : 0;
+      const seqSegStart = seqStart + (relStart - inPoint);
+      const seqSegEnd = seqSegStart + relDuration;
+      if (seqSegEnd <= seqSegStart) continue;
+
+      segments.push({
+        startSeconds: seqSegStart,
+        endSeconds: seqSegEnd,
+        speaker: speakerNameForSegment(seg, speakers, stats.defaultSpeaker),
+        text: segmentText(seg.words),
+        sourceClip: projectItem.name || "",
+      });
+    }
+  }
+
+  async function walkTrackItems(sequence, trackType, segments, stats) {
+    let trackCount = 0;
+    try {
+      if (trackType === "video") {
+        trackCount = await sequence.getVideoTrackCount();
+      } else {
+        trackCount = await sequence.getAudioTrackCount();
+      }
+    } catch (e) {
+      stats.errors.push("track count failed: " + e.message);
+      return;
+    }
+
+    const clipType = ppro.Constants.TrackItemType.CLIP;
+
+    for (let t = 0; t < trackCount; t++) {
+      let track;
+      try {
+        track = trackType === "video"
+          ? await sequence.getVideoTrack(t)
+          : await sequence.getAudioTrack(t);
+      } catch (e) {
+        stats.errors.push("getTrack(" + t + ") failed: " + e.message);
+        continue;
+      }
+      if (!track || typeof track.getTrackItems !== "function") continue;
+
+      let items = [];
+      try {
+        items = track.getTrackItems(clipType, false) || [];
+      } catch (e) {
+        stats.errors.push("getTrackItems failed on track " + t + ": " + e.message);
+        continue;
+      }
+
+      for (let i = 0; i < items.length; i++) {
+        await collectFromTrackItem(items[i], segments, stats, stats.fps);
+      }
+    }
+  }
+
+  function formatPrtranscript(segments, fps) {
+    const lines = [];
+    for (let i = 0; i < segments.length; i++) {
+      const seg = segments[i];
+      if (!seg.text) continue;
+      lines.push(
+        secondsToTimecode(seg.startSeconds, fps) + " - " + secondsToTimecode(seg.endSeconds, fps)
+      );
+      lines.push(seg.speaker || "Unknown");
+      lines.push(seg.text);
+      lines.push("");
+    }
+    return lines.join("\n").trim() + (lines.length ? "\n" : "");
+  }
+
+  function formatPlainText(segments) {
+    const lines = [];
+    for (let i = 0; i < segments.length; i++) {
+      const seg = segments[i];
+      if (!seg.text) continue;
+      lines.push("[" + seg.startSeconds.toFixed(3) + "] " + seg.speaker + ": " + seg.text);
+    }
+    return lines.join("\n").trim() + (lines.length ? "\n" : "");
+  }
+
+  async function exportSequenceTranscript(params) {
+    const outputPath = params && params.outputPath ? String(params.outputPath) : "";
+    const format = (params && params.format ? String(params.format) : "prtranscript").toLowerCase();
+    const defaultSpeaker = params && params.speakerLabel ? String(params.speakerLabel) : "Unknown";
+    const includeAudioTracks = !!(params && (params.includeAudioTracks || params.include_audio_tracks));
+
+    if (!outputPath) {
+      return { success: false, error: "outputPath is required" };
+    }
+
+    const project = await ppro.Project.getActiveProject();
+    if (!project) {
+      return { success: false, error: "No project is open" };
+    }
+
+    const sequence = await project.getActiveSequence();
+    if (!sequence) {
+      return { success: false, error: "No active sequence" };
+    }
+
+    const fps = await getSequenceFps(sequence);
+    const segments = [];
+    const stats = {
+      fps: fps,
+      defaultSpeaker: defaultSpeaker,
+      clipsWithTranscript: 0,
+      clipsWithoutTranscript: 0,
+      errors: [],
+      sequenceName: sequence.name || "",
+    };
+
+    await walkTrackItems(sequence, "video", segments, stats);
+    if (includeAudioTracks) {
+      await walkTrackItems(sequence, "audio", segments, stats);
+    }
+
+    segments.sort(function (a, b) { return a.startSeconds - b.startSeconds; });
+
+    if (segments.length === 0) {
+      return {
+        success: false,
+        error: "No transcript segments found on the active sequence. Transcribe source clips in Text > Transcript, then retry.",
+        sequenceName: stats.sequenceName,
+        clipsWithTranscript: stats.clipsWithTranscript,
+        clipsWithoutTranscript: stats.clipsWithoutTranscript,
+        errors: stats.errors,
+        uxpTranscriptApi: true,
+      };
+    }
+
+    let content;
+    if (format === "json") {
+      content = JSON.stringify({
+        sequenceName: stats.sequenceName,
+        fps: fps,
+        segmentCount: segments.length,
+        segments: segments,
+        stats: {
+          clipsWithTranscript: stats.clipsWithTranscript,
+          clipsWithoutTranscript: stats.clipsWithoutTranscript,
+          errors: stats.errors,
+        },
+      }, null, 2);
+    } else if (format === "text" || format === "txt") {
+      content = formatPlainText(segments);
+    } else {
+      content = formatPrtranscript(segments, fps);
+    }
+
+    await writeTextFile(outputPath, content);
+
+    return {
+      success: true,
+      outputPath: outputPath,
+      format: format,
+      segmentCount: segments.length,
+      sequenceName: stats.sequenceName,
+      fps: fps,
+      clipsWithTranscript: stats.clipsWithTranscript,
+      clipsWithoutTranscript: stats.clipsWithoutTranscript,
+      errors: stats.errors,
+      uxpTranscriptApi: true,
+    };
+  }
+
+  async function handleCommand(message) {
+    const action = message.action;
+    const params = message.params || {};
+    const requestId = message.requestId;
+
+    if (action === "ping") {
+      return {
+        requestId: requestId,
+        success: true,
+        result: {
+          role: "uxp-panel",
+          version: VERSION,
+          transcriptApi: true,
+        },
+      };
+    }
+
+    if (action === "exportSequenceTranscript") {
+      try {
+        const result = await exportSequenceTranscript(params);
+        return {
+          requestId: requestId,
+          success: !!result.success,
+          result: result,
+          error: result.success ? undefined : result.error,
+        };
+      } catch (e) {
+        return {
+          requestId: requestId,
+          success: false,
+          error: e && e.message ? e.message : String(e),
+        };
+      }
+    }
+
+    return {
+      requestId: requestId,
+      success: false,
+      error: "Unknown UXP action: " + action,
+    };
+  }
+
+  function scheduleReconnect() {
+    if (reconnectTimer) return;
+    reconnectTimer = setTimeout(function () {
+      reconnectTimer = null;
+      connect();
+    }, RECONNECT_MS);
+  }
+
+  function connect() {
+    if (ws && (ws.readyState === WebSocket.CONNECTING || ws.readyState === WebSocket.OPEN)) {
+      return;
+    }
+
+    if (wsUrlInput && wsUrlInput.value) {
+      saveWsUrl(wsUrlInput.value.trim());
+    }
+
+    setStatus("Connecting to " + wsUrl + "...", "warn");
+    log("Connecting to " + wsUrl);
+
+    try {
+      ws = new WebSocket(wsUrl);
+    } catch (e) {
+      setStatus("WebSocket error: " + e.message, "err");
+      scheduleReconnect();
+      return;
+    }
+
+    ws.onopen = function () {
+      setStatus("Connected (v" + VERSION + ")", "ok");
+      log("Connected");
+      try {
+        ws.send(JSON.stringify({ type: "hello", role: "uxp-panel", version: VERSION }));
+      } catch (e) { /* ignore */ }
+    };
+
+    ws.onclose = function () {
+      setStatus("Disconnected — retrying...", "warn");
+      log("Disconnected");
+      scheduleReconnect();
+    };
+
+    ws.onerror = function () {
+      setStatus("WebSocket error — retrying...", "err");
+    };
+
+    ws.onmessage = async function (event) {
+      let message;
+      try {
+        message = JSON.parse(event.data);
+      } catch (e) {
+        log("Invalid JSON from MCP: " + e.message, "error");
+        return;
+      }
+
+      const response = await handleCommand(message);
+      try {
+        ws.send(JSON.stringify(response));
+      } catch (e) {
+        log("Failed to send response: " + e.message, "error");
+      }
+    };
+  }
+
+  if (btnReconnect) {
+    btnReconnect.addEventListener("click", function () {
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+      if (ws) {
+        try { ws.close(); } catch (e) { /* ignore */ }
+        ws = null;
+      }
+      connect();
+    });
+  }
+
+  if (btnClear && logEl) {
+    btnClear.addEventListener("click", function () {
+      logEl.textContent = "";
+    });
+  }
+
+  loadWsUrl();
+  connect();
+})();


### PR DESCRIPTION
# WIP — `25.x`/`24.x`: Premiere MCP + CEP reliability (Pr 25.x)

## Summary

Hard end-to-end fixes for Cursor/MCP workflows against **Premiere Pro (CEP)**: correct handling of ExtendScript payloads, **`getSequenceList`** unmarshaling, clip/MOGRT tooling over **`evalCommand`**, **`premiere_ping`** accuracy, and Windows launcher / embedded TS bridge lifecycle so the bridge does not linger when Cursor shuts down MCP.

## Motivation / problems addressed

- **Ping vs reality:** Bridge reported healthy ping while ExtendScript envelopes (`success` / `data`) were not normalized for the TS layer.
- **Empty sequence list:** Go expected raw arrays or mismatched shapes; CEP returned wrapped `{ success, data }` and `sequence_id`-style keys.
- **`EvalScript error` on clips / MOGRTs:** **`evalCommand`** sent a single JSON string argument; Premiere helpers expect positional args (track type, indexes, text, etc.).
- **Lazy `premiere.jsx` load stuck wrong:** **`premiereJsxLoaded`** was flipped after **any** successful **`evalCommand`**, including core-only calls (e.g. **`getSequenceList`**), which skipped the lazy-load guard so **`premiere.jsx`** functions stayed undefined (clips/MOGRT calls failed).

## Changes (high level)

| Area | What changed |
|------|----------------|
| **CEP panel (`panel.js`)** | **`expandEvalCommandArgs`** for **`getClipsOnTrack`**, **`getMOGRTProperties`**, **`setMOGRTText`**, **`setMOGRTProperty`** → positional ExtendScript. Always emit lazy-load guard for **`evalCommand`**; remove incorrect **`premiereJsxLoaded`** promotion on unrelated eval successes. |
| **`core.jsx` / `premiere.jsx`** | **`getSequenceList`** uses snake_case (`sequence_id`, `active_sequence_id`, …) aligned with Go structs; **`_tryParseJSONObjectString`** (and similar) for single-string JSON blobs where belt-and-suspenders helps. |
| **Go orchestrator** | **`GetSequenceList`**: unwrap **`data`** envelope; shared helpers (**`eval_unpack`**). **`main.go`**: wired for embedded bridge where applicable. |
| **Embedded bridge (Windows)** | Job object / launcher path so **`server.exe`** can spawn and tear down the TS bridge cleanly on Windows. |
| **TS bridge (`cep-bridge.ts`)** | Map CEP **`ping`** payload (**`_ok`** / **`data`** / naming) → **`PingResponse`**. |
| **Cursor MCP launcher** | **`scripts/cursor-mcp-launcher.cjs`** (+ **`.cmd`**) orchestrate Go + **`--embed-ts-bridge`**, **`taskkill`**, stdin teardown. |
| **CEP ergonomics** | **`CSInterface.js`** refreshed; ExtendScript **`evalFile`** path resolution / error surfacing tightened. |

## Test / verification (manual)

- **`premiere_ping`:** Premiere running, project open, CEP mode consistent with panel.
- **`premiere_get_sequence_list`:** non-zero sequences; **`is_active`** / IDs sensible.
- **`premiere_get_clips_on_track`** + **`premiere_get_mogrt_properties`** + **`premiere_set_mogrt_text`:** exercised on stacked MOGRTs (multi-track).

## Outstanding / follow-ups (WIP)

- [ ] Expand automated tests for **`eval_unpack`** + key variants if not already sufficient.
- [ ] Document **`mcp.json`** pattern for **`--transport stdio --embed-ts-bridge`** (Windows-focused).
- [ ] Sanity pass on **`premiere_evaluate_expression`** / other **`evalCommand`** paths still passing JSON as one escaped string (may need **`expandEvalCommandArgs`** entries or jsx-side parsers).