### PR TITLE
Fix Windows support: the CEP bridge could never reach Premiere

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -19,8 +19,12 @@ proto-lint:
 # ─── Go Orchestrator ───
 
 # Build the Go orchestrator
+# Output to bin/ rather than bin/server so Go picks the platform-correct name:
+# server.exe on Windows, server elsewhere. With an explicit extension-less -o,
+# Windows produces a file it then cannot exec -- an MCP client spawning it
+# fails with ENOENT.
 go-build:
-    cd go-orchestrator && go build -o bin/server ./cmd/server
+    cd go-orchestrator && go build -o bin/ ./cmd/server
 
 # Run the Go orchestrator
 go-run:

--- a/Justfile
+++ b/Justfile
@@ -9,6 +9,8 @@ default:
 proto:
     @echo "Generating protobuf stubs..."
     buf generate proto/definitions
+    @echo "Restoring gen/go/go.mod (buf's clean:true wipes it on every generate)..."
+    ./scripts/restore-gen-go-mod.sh
 
 # Lint proto definitions
 proto-lint:

--- a/Start Premiere MCP.bat
+++ b/Start Premiere MCP.bat
@@ -1,0 +1,11 @@
+@echo off
+REM Double-click to launch Premiere Pro with the MCP bridge and start the
+REM backend services. See scripts\launch-premiere-mcp.ps1 for what it does
+REM and why the CEP cache has to be cleared first.
+REM
+REM If Premiere is already open this stops and tells you to quit it first,
+REM because CEP decides whether the extension may load during startup.
+REM Add -Force to close Premiere automatically (save your work first).
+
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\launch-premiere-mcp.ps1" %*
+pause

--- a/Start Premiere MCP.bat
+++ b/Start Premiere MCP.bat
@@ -1,11 +1,13 @@
 @echo off
-REM Double-click to launch Premiere Pro with the MCP bridge and start the
-REM backend services. See scripts\launch-premiere-mcp.ps1 for what it does
-REM and why the CEP cache has to be cleared first.
+REM Convenience launcher: opens Premiere Pro with a project and starts the
+REM backend services in one step. You do not need it for normal use --
+REM quitting Premiere normally and reopening a project works on its own.
+REM Its one real job is recovering after a crash or force-kill, which can
+REM leave orphaned CEPHtmlEngine processes that break extension loading.
 REM
 REM If Premiere is already open this stops and tells you to quit it first,
-REM because CEP decides whether the extension may load during startup.
-REM Add -Force to close Premiere automatically (save your work first).
+REM because extensions register at startup. Add -Force to close it for you
+REM (save your work first). See scripts\launch-premiere-mcp.ps1 for detail.
 
 powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\launch-premiere-mcp.ps1" %*
 pause

--- a/cep-panel/package.json
+++ b/cep-panel/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "main": "src/panel.js",
   "scripts": {
+    "build": "echo No build step required - plain JS CEP panel",
     "install-deps": "npm install",
     "setup-csinterface": "node scripts/setup-csinterface.js",
     "link-panel:mac": "ln -sf \"$(pwd)\" \"$HOME/Library/Application Support/Adobe/CEP/extensions/com.premierpro.mcp.bridge\"",

--- a/cep-panel/src/host/core.jsx
+++ b/cep-panel/src/host/core.jsx
@@ -29,7 +29,7 @@ if (typeof JSON === "undefined") {
     };
 }
 
-// ── Shared Helpers ────────────────────────────────────────────────────
+// -- Shared Helpers ----------------------------------------------------
 
 /**
  * Safely parse JSON arguments and validate required fields.
@@ -70,14 +70,14 @@ function _requireProject() {
 
 /**
  * Require an active sequence. Returns the sequence on success, or null.
- * If null, caller should return _err("No active sequence…").
+ * If null, caller should return _err("No active sequence...").
  */
 function _requireSequence() {
     if (!app.project) return null;
     return app.project.activeSequence || null;
 }
 
-// ── Project ───────────────────────────────────────────────────────────
+// -- Project -----------------------------------------------------------
 
 function ping() {
     try {
@@ -169,7 +169,7 @@ function closeProject(argsJson) {
     } catch (e) { return _err("Failed to close project: " + e.message); }
 }
 
-// ── Sequences ─────────────────────────────────────────────────────────
+// -- Sequences ---------------------------------------------------------
 
 function createSequence(argsJson) {
     try {
@@ -223,7 +223,7 @@ function getSequenceList() {
     } catch (e) { return _err("Failed to list sequences: " + e.message); }
 }
 
-// ── Media Import ──────────────────────────────────────────────────────
+// -- Media Import ------------------------------------------------------
 
 function importFiles(argsJson) {
     try {
@@ -271,7 +271,7 @@ function importFolder(argsJson) {
     } catch (e) { return _err("Failed to import folder '" + (folderPath || "unknown") + "': " + e.message); }
 }
 
-// ── Clips ─────────────────────────────────────────────────────────────
+// -- Clips -------------------------------------------------------------
 
 function getTimelineState(argsJson) {
     try {
@@ -408,7 +408,7 @@ function placeClip(argsJson) {
     } catch (e) { return _err("Failed to place clip: " + e.message); }
 }
 
-// ── Export ─────────────────────────────────────────────────────────────
+// -- Export -------------------------------------------------------------
 
 function exportSequence(argsJson) {
     try {
@@ -423,7 +423,7 @@ function exportSequence(argsJson) {
     } catch (e) { return _err("Failed to export sequence: " + e.message); }
 }
 
-// ── Bins ──────────────────────────────────────────────────────────────
+// -- Bins --------------------------------------------------------------
 
 function createBin(argsJson) {
     try {
@@ -460,7 +460,7 @@ function getProjectItems(argsJson) {
     } catch (e) { return _err("Failed to get project items: " + e.message); }
 }
 
-// ── Markers ───────────────────────────────────────────────────────────
+// -- Markers -----------------------------------------------------------
 
 function addSequenceMarker(argsJson) {
     try {
@@ -480,7 +480,7 @@ function addSequenceMarker(argsJson) {
     } catch (e) { return _err("Failed to add sequence marker: " + e.message); }
 }
 
-// ── Playback ──────────────────────────────────────────────────────────
+// -- Playback ----------------------------------------------------------
 
 function getPlayheadPosition() {
     try {
@@ -508,7 +508,7 @@ function setPlayheadPosition(argsJson) {
     } catch (e) { return _err("Failed to set playhead to " + (args && args.seconds !== undefined ? args.seconds + "s" : "unknown position") + ": " + e.message); }
 }
 
-// ── Audio ─────────────────────────────────────────────────────────────
+// -- Audio -------------------------------------------------------------
 
 function setAudioLevel(argsJson) {
     try {
@@ -548,7 +548,7 @@ function setAudioLevel(argsJson) {
     } catch (e) { return _err("Failed to set audio level: " + e.message); }
 }
 
-// ── Effects ───────────────────────────────────────────────────────────
+// -- Effects -----------------------------------------------------------
 
 function getClipEffects(argsJson) {
     try {
@@ -594,7 +594,7 @@ function getClipEffects(argsJson) {
     } catch (e) { return _err("Failed to get clip effects: " + e.message); }
 }
 
-// ── Transitions (QE DOM) ──────────────────────────────────────────────
+// -- Transitions (QE DOM) ----------------------------------------------
 
 function addVideoTransition(argsJson) {
     try {
@@ -629,7 +629,7 @@ function addVideoTransition(argsJson) {
     } catch (e) { return _err("Failed to add transition: " + e.message); }
 }
 
-// ── Color ─────────────────────────────────────────────────────────────
+// -- Color -------------------------------------------------------------
 
 function setLumetriProperty(argsJson) {
     try {
@@ -684,7 +684,7 @@ function setLumetriProperty(argsJson) {
     } catch (e) { return _err("Failed to set Lumetri property '" + (args && args.property ? args.property : "unknown") + "': " + e.message); }
 }
 
-// ── Motion ────────────────────────────────────────────────────────────
+// -- Motion ------------------------------------------------------------
 
 function setPosition(argsJson) {
     try {
@@ -787,7 +787,7 @@ function setOpacity(argsJson) {
     } catch (e) { return _err("Failed to set opacity: " + e.message); }
 }
 
-// ── System ────────────────────────────────────────────────────────────
+// -- System ------------------------------------------------------------
 
 function getSystemInfo() {
     try {
@@ -801,7 +801,7 @@ function getSystemInfo() {
     } catch (e) { return _err("Failed to get system info: " + e.message); }
 }
 
-// ── Tool Categories (for discoverability) ─────────────────────────────
+// -- Tool Categories (for discoverability) -----------------------------
 
 function getToolCategories() {
     return _ok({
@@ -831,7 +831,7 @@ function getToolCategories() {
     });
 }
 
-// ── Media Browser ─────────────────────────────────────────────────────
+// -- Media Browser -----------------------------------------------------
 
 function browsePath(argsJson) {
     try {
@@ -944,7 +944,7 @@ function getRecentLocations() {
     } catch (e) { return _err("Failed to get recent locations: " + e.message); }
 }
 
-// ── Timeline Panel Menu Items ─────────────────────────────────────────
+// -- Timeline Panel Menu Items -----------------------------------------
 
 function setAudioWaveformLabelColor(argsJson) {
     try {
@@ -1097,7 +1097,7 @@ function setRectifiedAudioWaveforms(argsJson) {
     } catch (e) { return _err("Failed to set rectified audio waveforms: " + e.message); }
 }
 
-// ── Frame Capture ─────────────────────────────────────────────────────
+// -- Frame Capture -----------------------------------------------------
 
 function captureFrameAsBase64(argsJson) {
     try {
@@ -1167,7 +1167,7 @@ function _binaryToBase64(data) {
     return result;
 }
 
-// ── Secure Script Execution ───────────────────────────────────────────
+// -- Secure Script Execution -------------------------------------------
 
 function executeSecureScript(argsJson) {
     try {
@@ -1203,7 +1203,7 @@ function executeQEScript(argsJson) {
     } catch (e) { return _err("Failed to execute QE script: " + e.message); }
 }
 
-// ── Panel Docking via macOS Accessibility (AppleScript) ───────────────
+// -- Panel Docking via macOS Accessibility (AppleScript) ---------------
 
 function simulateMenuClick(argsJson) {
     try {

--- a/cep-panel/src/host/premiere.jsx
+++ b/cep-panel/src/host/premiere.jsx
@@ -4761,7 +4761,7 @@ function setLumetriTint(trackIndex, clipIndex, value) { try { return _setLumetri
 function setLumetriExposure(trackIndex, clipIndex, value) { try { return _setLumetriProperty(trackIndex, clipIndex, "Exposure", value); } catch (e) { return _err("setLumetriExposure failed: " + e.message); } }
 
 // ---------------------------------------------------------------------------
-// Lumetri Color — Extended (Comprehensive Color Correction)
+// Lumetri Color - Extended (Comprehensive Color Correction)
 // ---------------------------------------------------------------------------
 
 /**
@@ -4814,7 +4814,7 @@ function _getLumetriComponent(trackIndex, clipIndex) {
     return lumetri;
 }
 
-/** 1. lumetriGetAll — Get all Lumetri Color parameter values */
+/** 1. lumetriGetAll - Get all Lumetri Color parameter values */
 function lumetriGetAll(trackIndex, clipIndex) {
     try {
         if (!app.project) return _err("No project is open");
@@ -4849,67 +4849,67 @@ function lumetriGetAll(trackIndex, clipIndex) {
     } catch (e) { return _err("lumetriGetAll failed: " + e.message); }
 }
 
-/** 2. lumetriSetExposure — Set exposure (-4.0 to 4.0) */
+/** 2. lumetriSetExposure - Set exposure (-4.0 to 4.0) */
 function lumetriSetExposure(trackIndex, clipIndex, value) {
     try { value = Math.max(-4.0, Math.min(4.0, parseFloat(value) || 0)); return _setLumetriProperty(trackIndex, clipIndex, "Exposure", value); } catch (e) { return _err("lumetriSetExposure failed: " + e.message); }
 }
 
-/** 3. lumetriSetContrast — Set contrast (-100 to 100) */
+/** 3. lumetriSetContrast - Set contrast (-100 to 100) */
 function lumetriSetContrast(trackIndex, clipIndex, value) {
     try { value = Math.max(-100, Math.min(100, parseFloat(value) || 0)); return _setLumetriProperty(trackIndex, clipIndex, "Contrast", value); } catch (e) { return _err("lumetriSetContrast failed: " + e.message); }
 }
 
-/** 4. lumetriSetHighlights — Set highlights (-100 to 100) */
+/** 4. lumetriSetHighlights - Set highlights (-100 to 100) */
 function lumetriSetHighlights(trackIndex, clipIndex, value) {
     try { value = Math.max(-100, Math.min(100, parseFloat(value) || 0)); return _setLumetriProperty(trackIndex, clipIndex, "Highlights", value); } catch (e) { return _err("lumetriSetHighlights failed: " + e.message); }
 }
 
-/** 5. lumetriSetShadows — Set shadows (-100 to 100) */
+/** 5. lumetriSetShadows - Set shadows (-100 to 100) */
 function lumetriSetShadows(trackIndex, clipIndex, value) {
     try { value = Math.max(-100, Math.min(100, parseFloat(value) || 0)); return _setLumetriProperty(trackIndex, clipIndex, "Shadows", value); } catch (e) { return _err("lumetriSetShadows failed: " + e.message); }
 }
 
-/** 6. lumetriSetWhites — Set whites (-100 to 100) */
+/** 6. lumetriSetWhites - Set whites (-100 to 100) */
 function lumetriSetWhites(trackIndex, clipIndex, value) {
     try { value = Math.max(-100, Math.min(100, parseFloat(value) || 0)); return _setLumetriProperty(trackIndex, clipIndex, "Whites", value); } catch (e) { return _err("lumetriSetWhites failed: " + e.message); }
 }
 
-/** 7. lumetriSetBlacks — Set blacks (-100 to 100) */
+/** 7. lumetriSetBlacks - Set blacks (-100 to 100) */
 function lumetriSetBlacks(trackIndex, clipIndex, value) {
     try { value = Math.max(-100, Math.min(100, parseFloat(value) || 0)); return _setLumetriProperty(trackIndex, clipIndex, "Blacks", value); } catch (e) { return _err("lumetriSetBlacks failed: " + e.message); }
 }
 
-/** 8. lumetriSetTemperature — Set white balance temperature */
+/** 8. lumetriSetTemperature - Set white balance temperature */
 function lumetriSetTemperature(trackIndex, clipIndex, value) {
     try { value = parseFloat(value) || 0; return _setLumetriProperty(trackIndex, clipIndex, "Temperature", value); } catch (e) { return _err("lumetriSetTemperature failed: " + e.message); }
 }
 
-/** 9. lumetriSetTint — Set white balance tint */
+/** 9. lumetriSetTint - Set white balance tint */
 function lumetriSetTint(trackIndex, clipIndex, value) {
     try { value = parseFloat(value) || 0; return _setLumetriProperty(trackIndex, clipIndex, "Tint", value); } catch (e) { return _err("lumetriSetTint failed: " + e.message); }
 }
 
-/** 10. lumetriSetSaturation — Set saturation (0 to 200) */
+/** 10. lumetriSetSaturation - Set saturation (0 to 200) */
 function lumetriSetSaturation(trackIndex, clipIndex, value) {
     try { value = Math.max(0, Math.min(200, parseFloat(value) || 100)); return _setLumetriProperty(trackIndex, clipIndex, "Saturation", value); } catch (e) { return _err("lumetriSetSaturation failed: " + e.message); }
 }
 
-/** 11. lumetriSetVibrance — Set vibrance (-100 to 100) */
+/** 11. lumetriSetVibrance - Set vibrance (-100 to 100) */
 function lumetriSetVibrance(trackIndex, clipIndex, value) {
     try { value = Math.max(-100, Math.min(100, parseFloat(value) || 0)); return _setLumetriProperty(trackIndex, clipIndex, "Vibrance", value); } catch (e) { return _err("lumetriSetVibrance failed: " + e.message); }
 }
 
-/** 12. lumetriSetFadedFilm — Set faded film amount (0 to 100) */
+/** 12. lumetriSetFadedFilm - Set faded film amount (0 to 100) */
 function lumetriSetFadedFilm(trackIndex, clipIndex, value) {
     try { value = Math.max(0, Math.min(100, parseFloat(value) || 0)); return _setLumetriProperty(trackIndex, clipIndex, "Faded Film", value); } catch (e) { return _err("lumetriSetFadedFilm failed: " + e.message); }
 }
 
-/** 13. lumetriSetSharpen — Set sharpening (0 to 200) */
+/** 13. lumetriSetSharpen - Set sharpening (0 to 200) */
 function lumetriSetSharpen(trackIndex, clipIndex, value) {
     try { value = Math.max(0, Math.min(200, parseFloat(value) || 0)); return _setLumetriProperty(trackIndex, clipIndex, "Sharpen", value); } catch (e) { return _err("lumetriSetSharpen failed: " + e.message); }
 }
 
-/** 14. lumetriSetCurvePoint — Set a point on RGB/Luma curve (channel: luma/red/green/blue) */
+/** 14. lumetriSetCurvePoint - Set a point on RGB/Luma curve (channel: luma/red/green/blue) */
 function lumetriSetCurvePoint(trackIndex, clipIndex, channel, inputValue, outputValue) {
     try {
         if (!app.project) return _err("No project is open");
@@ -4930,7 +4930,7 @@ function lumetriSetCurvePoint(trackIndex, clipIndex, channel, inputValue, output
     } catch (e) { return _err("lumetriSetCurvePoint failed: " + e.message); }
 }
 
-/** 15. lumetriSetShadowColor — Set shadow color wheel */
+/** 15. lumetriSetShadowColor - Set shadow color wheel */
 function lumetriSetShadowColor(trackIndex, clipIndex, hue, saturation, brightness) {
     try {
         if (!app.project) return _err("No project is open");
@@ -4945,7 +4945,7 @@ function lumetriSetShadowColor(trackIndex, clipIndex, hue, saturation, brightnes
     } catch (e) { return _err("lumetriSetShadowColor failed: " + e.message); }
 }
 
-/** 16. lumetriSetMidtoneColor — Set midtone color wheel */
+/** 16. lumetriSetMidtoneColor - Set midtone color wheel */
 function lumetriSetMidtoneColor(trackIndex, clipIndex, hue, saturation, brightness) {
     try {
         if (!app.project) return _err("No project is open");
@@ -4960,7 +4960,7 @@ function lumetriSetMidtoneColor(trackIndex, clipIndex, hue, saturation, brightne
     } catch (e) { return _err("lumetriSetMidtoneColor failed: " + e.message); }
 }
 
-/** 17. lumetriSetHighlightColor — Set highlight color wheel */
+/** 17. lumetriSetHighlightColor - Set highlight color wheel */
 function lumetriSetHighlightColor(trackIndex, clipIndex, hue, saturation, brightness) {
     try {
         if (!app.project) return _err("No project is open");
@@ -4975,27 +4975,27 @@ function lumetriSetHighlightColor(trackIndex, clipIndex, hue, saturation, bright
     } catch (e) { return _err("lumetriSetHighlightColor failed: " + e.message); }
 }
 
-/** 18. lumetriSetVignetteAmount — Set vignette amount */
+/** 18. lumetriSetVignetteAmount - Set vignette amount */
 function lumetriSetVignetteAmount(trackIndex, clipIndex, value) {
     try { value = Math.max(-5, Math.min(5, parseFloat(value) || 0)); return _setLumetriProperty(trackIndex, clipIndex, "Vignette Amount", value); } catch (e) { return _err("lumetriSetVignetteAmount failed: " + e.message); }
 }
 
-/** 19. lumetriSetVignetteMidpoint — Set vignette midpoint */
+/** 19. lumetriSetVignetteMidpoint - Set vignette midpoint */
 function lumetriSetVignetteMidpoint(trackIndex, clipIndex, value) {
     try { value = Math.max(0, Math.min(100, parseFloat(value) || 50)); return _setLumetriProperty(trackIndex, clipIndex, "Vignette Midpoint", value); } catch (e) { return _err("lumetriSetVignetteMidpoint failed: " + e.message); }
 }
 
-/** 20. lumetriSetVignetteRoundness — Set vignette roundness */
+/** 20. lumetriSetVignetteRoundness - Set vignette roundness */
 function lumetriSetVignetteRoundness(trackIndex, clipIndex, value) {
     try { value = Math.max(-100, Math.min(100, parseFloat(value) || 0)); return _setLumetriProperty(trackIndex, clipIndex, "Vignette Roundness", value); } catch (e) { return _err("lumetriSetVignetteRoundness failed: " + e.message); }
 }
 
-/** 21. lumetriSetVignetteFeather — Set vignette feather */
+/** 21. lumetriSetVignetteFeather - Set vignette feather */
 function lumetriSetVignetteFeather(trackIndex, clipIndex, value) {
     try { value = Math.max(0, Math.min(100, parseFloat(value) || 50)); return _setLumetriProperty(trackIndex, clipIndex, "Vignette Feather", value); } catch (e) { return _err("lumetriSetVignetteFeather failed: " + e.message); }
 }
 
-/** 22. lumetriApplyLUT — Apply a LUT file (.cube, .3dl) */
+/** 22. lumetriApplyLUT - Apply a LUT file (.cube, .3dl) */
 function lumetriApplyLUT(trackIndex, clipIndex, lutPath) {
     try {
         if (!app.project) return _err("No project is open");
@@ -5013,7 +5013,7 @@ function lumetriApplyLUT(trackIndex, clipIndex, lutPath) {
     } catch (e) { return _err("lumetriApplyLUT failed: " + e.message); }
 }
 
-/** 23. lumetriRemoveLUT — Remove applied LUT */
+/** 23. lumetriRemoveLUT - Remove applied LUT */
 function lumetriRemoveLUT(trackIndex, clipIndex) {
     try {
         if (!app.project) return _err("No project is open");
@@ -5025,7 +5025,7 @@ function lumetriRemoveLUT(trackIndex, clipIndex) {
     } catch (e) { return _err("lumetriRemoveLUT failed: " + e.message); }
 }
 
-/** 24. lumetriAutoColor — Auto color correction (applies reasonable defaults) */
+/** 24. lumetriAutoColor - Auto color correction (applies reasonable defaults) */
 function lumetriAutoColor(trackIndex, clipIndex) {
     try {
         if (!app.project) return _err("No project is open");
@@ -5038,7 +5038,7 @@ function lumetriAutoColor(trackIndex, clipIndex) {
     } catch (e) { return _err("lumetriAutoColor failed: " + e.message); }
 }
 
-/** 25. lumetriReset — Reset all Lumetri settings to default */
+/** 25. lumetriReset - Reset all Lumetri settings to default */
 function lumetriReset(trackIndex, clipIndex) {
     try {
         if (!app.project) return _err("No project is open");
@@ -5051,7 +5051,7 @@ function lumetriReset(trackIndex, clipIndex) {
     } catch (e) { return _err("lumetriReset failed: " + e.message); }
 }
 
-/** 26. getColorInfo — Get basic color statistics for a clip */
+/** 26. getColorInfo - Get basic color statistics for a clip */
 function getColorInfo(trackIndex, clipIndex) {
     try {
         if (!app.project) return _err("No project is open");
@@ -5078,7 +5078,7 @@ function getColorInfo(trackIndex, clipIndex) {
 /** Internal variable to store copied Lumetri settings for paste operations */
 var _copiedLumetriSettings = null;
 
-/** 27. copyColorGrade — Copy Lumetri settings from a source clip */
+/** 27. copyColorGrade - Copy Lumetri settings from a source clip */
 function copyColorGrade(srcTrackIndex, srcClipIndex) {
     try {
         if (!app.project) return _err("No project is open");
@@ -5090,7 +5090,7 @@ function copyColorGrade(srcTrackIndex, srcClipIndex) {
     } catch (e) { return _err("copyColorGrade failed: " + e.message); }
 }
 
-/** 28. pasteColorGrade — Paste previously copied Lumetri settings */
+/** 28. pasteColorGrade - Paste previously copied Lumetri settings */
 function pasteColorGrade(destTrackIndex, destClipIndex) {
     try {
         if (!app.project) return _err("No project is open");
@@ -5103,7 +5103,7 @@ function pasteColorGrade(destTrackIndex, destClipIndex) {
     } catch (e) { return _err("pasteColorGrade failed: " + e.message); }
 }
 
-/** 29. applyColorGradeToAll — Apply grade from source clip to all clips on a track */
+/** 29. applyColorGradeToAll - Apply grade from source clip to all clips on a track */
 function applyColorGradeToAll(srcTrackIndex, srcClipIndex, trackIndex) {
     try {
         if (!app.project) return _err("No project is open");
@@ -5124,7 +5124,7 @@ function applyColorGradeToAll(srcTrackIndex, srcClipIndex, trackIndex) {
     } catch (e) { return _err("applyColorGradeToAll failed: " + e.message); }
 }
 
-/** 30. lumetriAutoWhiteBalance — Auto white balance (resets temperature and tint to neutral) */
+/** 30. lumetriAutoWhiteBalance - Auto white balance (resets temperature and tint to neutral) */
 function lumetriAutoWhiteBalance(trackIndex, clipIndex) {
     try {
         if (!app.project) return _err("No project is open");
@@ -9758,7 +9758,7 @@ function extractAudioFromVideo(projectItemIndex) {
 // ---------------------------------------------------------------------------
 
 /**
- * 1. getGeneralPreferences — Get general preferences.
+ * 1. getGeneralPreferences - Get general preferences.
  */
 function getGeneralPreferences() {
     try {
@@ -9783,7 +9783,7 @@ function getGeneralPreferences() {
 }
 
 /**
- * 2. setDefaultStillDuration — Set default still image duration in frames.
+ * 2. setDefaultStillDuration - Set default still image duration in frames.
  */
 function setDefaultStillDuration(frames) {
     try {
@@ -9801,7 +9801,7 @@ function setDefaultStillDuration(frames) {
 }
 
 /**
- * 3. setDefaultTransitionDuration — Set default video transition duration in seconds.
+ * 3. setDefaultTransitionDuration - Set default video transition duration in seconds.
  */
 function setDefaultTransitionDuration(seconds) {
     try {
@@ -9818,7 +9818,7 @@ function setDefaultTransitionDuration(seconds) {
 }
 
 /**
- * 4. setDefaultAudioTransitionDuration — Set default audio transition duration in seconds.
+ * 4. setDefaultAudioTransitionDuration - Set default audio transition duration in seconds.
  */
 function setDefaultAudioTransitionDuration(seconds) {
     try {
@@ -9839,7 +9839,7 @@ function setDefaultAudioTransitionDuration(seconds) {
 // ---------------------------------------------------------------------------
 
 /**
- * 5. getBrightness — Get UI brightness level.
+ * 5. getBrightness - Get UI brightness level.
  */
 function getBrightness() {
     try {
@@ -9852,7 +9852,7 @@ function getBrightness() {
 }
 
 /**
- * 6. setBrightness — Set UI brightness (0-255).
+ * 6. setBrightness - Set UI brightness (0-255).
  */
 function setBrightness(level) {
     try {
@@ -9876,7 +9876,7 @@ function setBrightness(level) {
 // ---------------------------------------------------------------------------
 
 /**
- * 7. setAutoSaveEnabled — Enable/disable auto-save.
+ * 7. setAutoSaveEnabled - Enable/disable auto-save.
  */
 function setAutoSaveEnabled(enabled) {
     try {
@@ -9891,7 +9891,7 @@ function setAutoSaveEnabled(enabled) {
 }
 
 /**
- * 8. setAutoSaveMaxVersions — Set max auto-save versions.
+ * 8. setAutoSaveMaxVersions - Set max auto-save versions.
  */
 function setAutoSaveMaxVersions(count) {
     try {
@@ -9909,7 +9909,7 @@ function setAutoSaveMaxVersions(count) {
 }
 
 /**
- * 9. getAutoSaveLocation — Get auto-save folder location.
+ * 9. getAutoSaveLocation - Get auto-save folder location.
  */
 function getAutoSaveLocation() {
     try {
@@ -9933,7 +9933,7 @@ function getAutoSaveLocation() {
 // ---------------------------------------------------------------------------
 
 /**
- * 10. getPlaybackResolution — Get playback resolution setting.
+ * 10. getPlaybackResolution - Get playback resolution setting.
  */
 function getPlaybackResolution() {
     try {
@@ -9951,7 +9951,7 @@ function getPlaybackResolution() {
 }
 
 /**
- * 11. setPlaybackResolution — Set playback resolution (full, 1/2, 1/4, 1/8, 1/16).
+ * 11. setPlaybackResolution - Set playback resolution (full, 1/2, 1/4, 1/8, 1/16).
  */
 function setPlaybackResolution(quality) {
     try {
@@ -9978,7 +9978,7 @@ function setPlaybackResolution(quality) {
 }
 
 /**
- * 12. getPrerollFrames — Get pre-roll frames.
+ * 12. getPrerollFrames - Get pre-roll frames.
  */
 function getPrerollFrames() {
     try {
@@ -9991,7 +9991,7 @@ function getPrerollFrames() {
 }
 
 /**
- * 13. setPrerollFrames — Set pre-roll frames.
+ * 13. setPrerollFrames - Set pre-roll frames.
  */
 function setPrerollFrames(frames) {
     try {
@@ -10009,7 +10009,7 @@ function setPrerollFrames(frames) {
 }
 
 /**
- * 14. getPostrollFrames — Get post-roll frames.
+ * 14. getPostrollFrames - Get post-roll frames.
  */
 function getPostrollFrames() {
     try {
@@ -10022,7 +10022,7 @@ function getPostrollFrames() {
 }
 
 /**
- * 15. setPostrollFrames — Set post-roll frames.
+ * 15. setPostrollFrames - Set post-roll frames.
  */
 function setPostrollFrames(frames) {
     try {
@@ -10044,7 +10044,7 @@ function setPostrollFrames(frames) {
 // ---------------------------------------------------------------------------
 
 /**
- * 16. getTimelineSettings — Get all timeline preferences.
+ * 16. getTimelineSettings - Get all timeline preferences.
  */
 function getTimelineSettings() {
     try {
@@ -10066,7 +10066,7 @@ function getTimelineSettings() {
 }
 
 /**
- * 17. setTimeDisplayFormat — Set time display format (timecode, frames, feet+frames).
+ * 17. setTimeDisplayFormat - Set time display format (timecode, frames, feet+frames).
  */
 function setTimeDisplayFormat(format) {
     try {
@@ -10083,7 +10083,7 @@ function setTimeDisplayFormat(format) {
 }
 
 /**
- * 18. setVideoTransitionDefaultDuration — Set default video transition duration in frames.
+ * 18. setVideoTransitionDefaultDuration - Set default video transition duration in frames.
  */
 function setVideoTransitionDefaultDuration(frames) {
     try {
@@ -10105,7 +10105,7 @@ function setVideoTransitionDefaultDuration(frames) {
 // ---------------------------------------------------------------------------
 
 /**
- * 19. getMediaCacheSettings — Get media cache settings.
+ * 19. getMediaCacheSettings - Get media cache settings.
  */
 function getMediaCacheSettings() {
     try {
@@ -10123,7 +10123,7 @@ function getMediaCacheSettings() {
 }
 
 /**
- * 20. setMediaCacheLocation — Set media cache location.
+ * 20. setMediaCacheLocation - Set media cache location.
  */
 function setMediaCacheLocation(path) {
     try {
@@ -10144,7 +10144,7 @@ function setMediaCacheLocation(path) {
 }
 
 /**
- * 21. setMediaCacheSize — Set max media cache size in GB.
+ * 21. setMediaCacheSize - Set max media cache size in GB.
  */
 function setMediaCacheSize(maxGB) {
     try {
@@ -10161,7 +10161,7 @@ function setMediaCacheSize(maxGB) {
 }
 
 /**
- * 22. cleanMediaCacheOlderThan — Clean cache files older than N days.
+ * 22. cleanMediaCacheOlderThan - Clean cache files older than N days.
  */
 function cleanMediaCacheOlderThan(days) {
     try {
@@ -10198,7 +10198,7 @@ function cleanMediaCacheOlderThan(days) {
 // ---------------------------------------------------------------------------
 
 /**
- * 23. getLabelColorNames — Get all label color names.
+ * 23. getLabelColorNames - Get all label color names.
  */
 function getLabelColorNames() {
     try {
@@ -10224,7 +10224,7 @@ function getLabelColorNames() {
 }
 
 /**
- * 24. setLabelColorName — Rename a label color.
+ * 24. setLabelColorName - Rename a label color.
  */
 function setLabelColorName(index, name) {
     try {
@@ -10249,7 +10249,7 @@ function setLabelColorName(index, name) {
 // ---------------------------------------------------------------------------
 
 /**
- * 25. getRendererInfo — Get current renderer (Software, CUDA, Metal, OpenCL).
+ * 25. getRendererInfo - Get current renderer (Software, CUDA, Metal, OpenCL).
  */
 function getRendererInfo() {
     try {
@@ -10272,7 +10272,7 @@ function getRendererInfo() {
 }
 
 /**
- * 26. getGPUInfo — Get GPU information.
+ * 26. getGPUInfo - Get GPU information.
  */
 function getGPUInfo() {
     try {
@@ -10299,7 +10299,7 @@ function getGPUInfo() {
 }
 
 /**
- * 27. setRenderer — Set the active renderer.
+ * 27. setRenderer - Set the active renderer.
  */
 function setRenderer(rendererName) {
     try {
@@ -10320,7 +10320,7 @@ function setRenderer(rendererName) {
 // ---------------------------------------------------------------------------
 
 /**
- * 28. getDefaultSequencePresets — List available sequence presets.
+ * 28. getDefaultSequencePresets - List available sequence presets.
  */
 function getDefaultSequencePresets() {
     try {
@@ -10347,7 +10347,7 @@ function getDefaultSequencePresets() {
 }
 
 /**
- * 29. setDefaultSequencePreset — Set default sequence preset.
+ * 29. setDefaultSequencePreset - Set default sequence preset.
  */
 function setDefaultSequencePreset(presetPath) {
     try {
@@ -10368,7 +10368,7 @@ function setDefaultSequencePreset(presetPath) {
 }
 
 /**
- * 30. getInstalledCodecs — List installed codecs/formats.
+ * 30. getInstalledCodecs - List installed codecs/formats.
  */
 function getInstalledCodecs() {
     try {
@@ -12801,7 +12801,7 @@ function playMacro(name) {
 
 // ===========================================================================
 // VR / 360 Video, HDR, Stereoscopic, Frame Rate, Aspect Ratio, Timecode,
-// Render Settings, and Closed Captions (Extended) — Immersive & Advanced
+// Render Settings, and Closed Captions (Extended) - Immersive & Advanced
 // ===========================================================================
 
 // ---------------------------------------------------------------------------
@@ -14818,7 +14818,7 @@ function optimizeProject() {
 // ---------------------------------------------------------------------------
 
 /**
- * createMontage — Auto-assemble clips with transitions and background music.
+ * createMontage - Auto-assemble clips with transitions and background music.
  * @param {string} clipIndicesJSON - JSON array of project item indices
  * @param {string} transitionName - Transition to apply between clips
  * @param {number} transitionDuration - Transition duration in seconds
@@ -14878,7 +14878,7 @@ function createMontage(clipIndicesJSON, transitionName, transitionDuration, musi
 }
 
 /**
- * createSlideshow — Create a slideshow from images with transitions and music.
+ * createSlideshow - Create a slideshow from images with transitions and music.
  * @param {string} imageIndicesJSON - JSON array of project item indices for images
  * @param {number} slideDuration - Duration per slide in seconds
  * @param {string} transitionName - Transition between slides
@@ -14928,7 +14928,7 @@ function createSlideshow(imageIndicesJSON, slideDuration, transitionName, musicP
 }
 
 /**
- * createHighlightReel — Extract marker-tagged sections into a new highlight sequence.
+ * createHighlightReel - Extract marker-tagged sections into a new highlight sequence.
  * @param {number} sequenceIndex - Index of the source sequence
  * @param {string} markerColor - Marker color to filter (e.g. "Green")
  * @param {string} outputName - Name for the highlight sequence
@@ -14982,7 +14982,7 @@ function createHighlightReel(sequenceIndex, markerColor, outputName) {
 }
 
 /**
- * rippleDeleteEmptySpaces — Remove all empty spaces (gaps) across all tracks.
+ * rippleDeleteEmptySpaces - Remove all empty spaces (gaps) across all tracks.
  */
 function rippleDeleteEmptySpaces() {
     try {
@@ -15026,7 +15026,7 @@ function rippleDeleteEmptySpaces() {
 }
 
 /**
- * alignAllClipsToTrack — Move clips from one track to align with clips on another.
+ * alignAllClipsToTrack - Move clips from one track to align with clips on another.
  * @param {number} sourceTrack - Source video track index
  * @param {number} destTrack - Destination video track index
  */
@@ -15060,7 +15060,7 @@ function alignAllClipsToTrack(sourceTrack, destTrack) {
 // ---------------------------------------------------------------------------
 
 /**
- * syncAllAudioToVideo — Attempt to sync audio clips to corresponding video by timecode.
+ * syncAllAudioToVideo - Attempt to sync audio clips to corresponding video by timecode.
  */
 function syncAllAudioToVideo() {
     try {
@@ -15098,7 +15098,7 @@ function syncAllAudioToVideo() {
 }
 
 /**
- * replaceAudio — Replace the audio of a video clip at given track/clip index.
+ * replaceAudio - Replace the audio of a video clip at given track/clip index.
  * @param {number} videoTrackIndex - Video track index
  * @param {number} videoClipIndex - Clip index on the video track
  * @param {string} audioPath - Path to the replacement audio file
@@ -15130,7 +15130,7 @@ function replaceAudio(videoTrackIndex, videoClipIndex, audioPath) {
 }
 
 /**
- * addMusicBed — Add background music with fades and volume control.
+ * addMusicBed - Add background music with fades and volume control.
  * @param {string} audioPath - Path to the music file
  * @param {number} trackIndex - Audio track index
  * @param {number} startTime - Start time in seconds
@@ -15170,7 +15170,7 @@ function addMusicBed(audioPath, trackIndex, startTime, endTime, fadeIn, fadeOut,
 }
 
 /**
- * duckMusicUnderDialogue — Lower music volume under dialogue clips.
+ * duckMusicUnderDialogue - Lower music volume under dialogue clips.
  * @param {number} musicTrackIndex - Audio track index of music
  * @param {number} dialogueTrackIndex - Audio track index of dialogue
  * @param {number} duckAmount - Amount to duck in dB (positive number, e.g. 12)
@@ -15212,7 +15212,7 @@ function duckMusicUnderDialogue(musicTrackIndex, dialogueTrackIndex, duckAmount)
 }
 
 /**
- * addSoundEffect — Place a sound effect at a specific time on a track.
+ * addSoundEffect - Place a sound effect at a specific time on a track.
  * @param {string} sfxPath - Path to the sound effect file
  * @param {number} trackIndex - Audio track index
  * @param {number} time - Time in seconds to place the SFX
@@ -15240,7 +15240,7 @@ function addSoundEffect(sfxPath, trackIndex, time, volume) {
 // ---------------------------------------------------------------------------
 
 /**
- * matchColorBetweenClips — Copy Lumetri color settings from one clip to another.
+ * matchColorBetweenClips - Copy Lumetri color settings from one clip to another.
  * @param {number} srcTrackIndex - Source video track index
  * @param {number} srcClipIndex - Source clip index
  * @param {number} destTrackIndex - Destination video track index
@@ -15279,7 +15279,7 @@ function matchColorBetweenClips(srcTrackIndex, srcClipIndex, destTrackIndex, des
 }
 
 /**
- * applyColorPreset — Apply a named color preset to a clip.
+ * applyColorPreset - Apply a named color preset to a clip.
  * @param {number} trackIndex - Video track index
  * @param {number} clipIndex - Clip index
  * @param {string} presetName - Preset name (Warm, Cool, Vintage, Cinematic, Desaturated, HighContrast)
@@ -15311,7 +15311,7 @@ function applyColorPreset(trackIndex, clipIndex, presetName) {
 }
 
 /**
- * createColorGradient — Apply gradual color temperature change across clips.
+ * createColorGradient - Apply gradual color temperature change across clips.
  * @param {number} trackIndex - Video track index
  * @param {number} startClipIndex - First clip index
  * @param {number} endClipIndex - Last clip index
@@ -15352,7 +15352,7 @@ function createColorGradient(trackIndex, startClipIndex, endClipIndex, startTemp
 }
 
 /**
- * autoCorrectAllClips — Auto color correct all clips on a video track.
+ * autoCorrectAllClips - Auto color correct all clips on a video track.
  * @param {number} trackIndex - Video track index
  */
 function autoCorrectAllClips(trackIndex) {
@@ -15383,7 +15383,7 @@ function autoCorrectAllClips(trackIndex) {
 // ---------------------------------------------------------------------------
 
 /**
- * addSubtitlesFromSRT — Parse an SRT file and place subtitles on the timeline.
+ * addSubtitlesFromSRT - Parse an SRT file and place subtitles on the timeline.
  * @param {string} srtPath - Path to the SRT file
  * @param {number} trackIndex - Video track index for captions
  */
@@ -15424,7 +15424,7 @@ function addSubtitlesFromSRT(srtPath, trackIndex) {
 }
 
 /**
- * addEndCredits — Add scrolling end credits to the timeline.
+ * addEndCredits - Add scrolling end credits to the timeline.
  * @param {string} creditsJSON - JSON array of credit lines [{role, name}]
  * @param {number} trackIndex - Video track index
  * @param {number} scrollDuration - Duration of the credits scroll in seconds
@@ -15455,7 +15455,7 @@ function addEndCredits(creditsJSON, trackIndex, scrollDuration, style) {
 }
 
 /**
- * addChapterMarkers — Add chapter markers to the active sequence.
+ * addChapterMarkers - Add chapter markers to the active sequence.
  * @param {string} chaptersJSON - JSON array of [{time, title}]
  */
 function addChapterMarkers(chaptersJSON) {
@@ -15481,7 +15481,7 @@ function addChapterMarkers(chaptersJSON) {
 }
 
 /**
- * generateChaptersFromMarkers — Export markers as YouTube chapter format.
+ * generateChaptersFromMarkers - Export markers as YouTube chapter format.
  * @param {string} outputPath - File path to write the chapters text
  */
 function generateChaptersFromMarkers(outputPath) {
@@ -15530,7 +15530,7 @@ function generateChaptersFromMarkers(outputPath) {
 // ---------------------------------------------------------------------------
 
 /**
- * exportForYouTube — Export with YouTube-optimized settings (H.264, 1080p or 4K).
+ * exportForYouTube - Export with YouTube-optimized settings (H.264, 1080p or 4K).
  * @param {string} outputPath - Output file path
  * @param {string} title - Video title metadata
  * @param {string} description - Video description metadata
@@ -15566,7 +15566,7 @@ function exportForYouTube(outputPath, title, description) {
 }
 
 /**
- * exportForInstagram — Export for Instagram with specific aspect ratio.
+ * exportForInstagram - Export for Instagram with specific aspect ratio.
  * @param {string} outputPath - Output file path
  * @param {string} aspectRatio - "1:1", "4:5", or "9:16"
  */
@@ -15591,7 +15591,7 @@ function exportForInstagram(outputPath, aspectRatio) {
 }
 
 /**
- * exportForTikTok — Export for TikTok (9:16, <3 minutes, H.264).
+ * exportForTikTok - Export for TikTok (9:16, <3 minutes, H.264).
  * @param {string} outputPath - Output file path
  */
 function exportForTikTok(outputPath) {
@@ -15614,7 +15614,7 @@ function exportForTikTok(outputPath) {
 }
 
 /**
- * exportForTwitter — Export for Twitter (16:9, <2:20, H.264).
+ * exportForTwitter - Export for Twitter (16:9, <2:20, H.264).
  * @param {string} outputPath - Output file path
  */
 function exportForTwitter(outputPath) {
@@ -15638,7 +15638,7 @@ function exportForTwitter(outputPath) {
 }
 
 /**
- * exportMultipleFormats — Export in multiple formats at once.
+ * exportMultipleFormats - Export in multiple formats at once.
  * @param {string} outputDir - Output directory path
  * @param {string} formatsJSON - JSON array of format strings: ["youtube","instagram_square","tiktok","twitter"]
  */
@@ -15673,7 +15673,7 @@ function exportMultipleFormats(outputDir, formatsJSON) {
 // ---------------------------------------------------------------------------
 
 /**
- * setupNewProject — Full project setup with configuration.
+ * setupNewProject - Full project setup with configuration.
  * @param {string} name - Project name
  * @param {string} path - Project file path
  * @param {string} resolution - "1080p" or "4k"
@@ -15701,7 +15701,7 @@ function setupNewProject(name, path, resolution, fps, audioSampleRate) {
 }
 
 /**
- * setupEditingWorkspace — Complete workspace setup.
+ * setupEditingWorkspace - Complete workspace setup.
  * @param {string} projectPath - Project file path to open
  * @param {string} mediaFolder - Path to media folder to import
  * @param {string} sequenceName - Name for the initial sequence
@@ -15729,7 +15729,7 @@ function setupEditingWorkspace(projectPath, mediaFolder, sequenceName) {
 }
 
 /**
- * importAndOrganize — Import all media from a folder and auto-organize into bins.
+ * importAndOrganize - Import all media from a folder and auto-organize into bins.
  * @param {string} mediaFolder - Path to the media folder
  * @param {boolean} autoCreateBins - Whether to auto-create bins by type
  */
@@ -15774,7 +15774,7 @@ function importAndOrganize(mediaFolder, autoCreateBins) {
 }
 
 /**
- * prepareForDelivery — Check specs and prepare project for final delivery.
+ * prepareForDelivery - Check specs and prepare project for final delivery.
  * @param {string} specsJSON - JSON object with delivery specs {width, height, fps, audioDB, maxDuration}
  */
 function prepareForDelivery(specsJSON) {
@@ -15823,7 +15823,7 @@ function prepareForDelivery(specsJSON) {
 // ---------------------------------------------------------------------------
 
 /**
- * archiveProject — Archive the current project with optional media.
+ * archiveProject - Archive the current project with optional media.
  * @param {string} outputPath - Archive output path
  * @param {boolean} includeMedia - Include media files
  * @param {boolean} includeRenders - Include rendered files
@@ -15850,7 +15850,7 @@ function archiveProject(outputPath, includeMedia, includeRenders) {
 }
 
 /**
- * trimProject — Remove unused media and clean the project.
+ * trimProject - Remove unused media and clean the project.
  */
 function trimProject() {
     try {
@@ -15890,7 +15890,7 @@ function trimProject() {
 }
 
 /**
- * consolidateAndTranscode — Consolidate media and transcode to a single codec.
+ * consolidateAndTranscode - Consolidate media and transcode to a single codec.
  * @param {string} outputDir - Output directory for consolidated media
  * @param {string} codec - Target codec (e.g. "h264", "prores")
  * @param {string} quality - Quality preset ("low", "medium", "high")
@@ -16757,7 +16757,7 @@ function showDialog(title, message, buttons) {
 // ---------------------------------------------------------------------------
 
 /**
- * openPanel — Open a Premiere Pro panel by name.
+ * openPanel - Open a Premiere Pro panel by name.
  */
 function openPanel(panelName) {
     try {
@@ -16788,7 +16788,7 @@ function openPanel(panelName) {
 }
 
 /**
- * closePanel — Close a Premiere Pro panel by name.
+ * closePanel - Close a Premiere Pro panel by name.
  */
 function closePanel(panelName) {
     try {
@@ -16804,7 +16804,7 @@ function closePanel(panelName) {
 }
 
 /**
- * getOpenPanels — List currently open panels.
+ * getOpenPanels - List currently open panels.
  */
 function getOpenPanels() {
     try {
@@ -16828,7 +16828,7 @@ function getOpenPanels() {
 }
 
 /**
- * resetPanelLayout — Reset to default panel layout.
+ * resetPanelLayout - Reset to default panel layout.
  */
 function resetPanelLayout() {
     try {
@@ -16841,7 +16841,7 @@ function resetPanelLayout() {
 }
 
 /**
- * maximizePanel — Maximize a panel (full screen toggle).
+ * maximizePanel - Maximize a panel (full screen toggle).
  */
 function maximizePanel(panelName) {
     try {
@@ -16861,7 +16861,7 @@ function maximizePanel(panelName) {
 // ---------------------------------------------------------------------------
 
 /**
- * getWindowInfo — Get main window size and position.
+ * getWindowInfo - Get main window size and position.
  */
 function getWindowInfo() {
     try {
@@ -16893,7 +16893,7 @@ function getWindowInfo() {
 }
 
 /**
- * setWindowSize — Set main window size.
+ * setWindowSize - Set main window size.
  */
 function setWindowSize(width, height) {
     try {
@@ -16911,7 +16911,7 @@ function setWindowSize(width, height) {
 }
 
 /**
- * minimizeWindow — Minimize Premiere Pro.
+ * minimizeWindow - Minimize Premiere Pro.
  */
 function minimizeWindow() {
     try {
@@ -16923,7 +16923,7 @@ function minimizeWindow() {
 }
 
 /**
- * bringToFront — Bring Premiere Pro window to front.
+ * bringToFront - Bring Premiere Pro window to front.
  */
 function bringToFront() {
     try {
@@ -16936,7 +16936,7 @@ function bringToFront() {
 }
 
 /**
- * enterFullscreen — Enter fullscreen mode.
+ * enterFullscreen - Enter fullscreen mode.
  */
 function enterFullscreen() {
     try {
@@ -16953,7 +16953,7 @@ function enterFullscreen() {
 // ---------------------------------------------------------------------------
 
 /**
- * setTrackHeight — Set individual track height.
+ * setTrackHeight - Set individual track height.
  */
 function setTrackHeight(trackType, trackIndex, height) {
     try {
@@ -16980,7 +16980,7 @@ function setTrackHeight(trackType, trackIndex, height) {
 }
 
 /**
- * collapseTrack — Collapse a track.
+ * collapseTrack - Collapse a track.
  */
 function collapseTrack(trackType, trackIndex) {
     try {
@@ -17005,7 +17005,7 @@ function collapseTrack(trackType, trackIndex) {
 }
 
 /**
- * expandTrack — Expand a track.
+ * expandTrack - Expand a track.
  */
 function expandTrack(trackType, trackIndex) {
     try {
@@ -17031,7 +17031,7 @@ function expandTrack(trackType, trackIndex) {
 }
 
 /**
- * collapseAllTracks — Collapse all tracks.
+ * collapseAllTracks - Collapse all tracks.
  */
 function collapseAllTracks() {
     try {
@@ -17055,7 +17055,7 @@ function collapseAllTracks() {
 }
 
 /**
- * expandAllTracks — Expand all tracks.
+ * expandAllTracks - Expand all tracks.
  */
 function expandAllTracks() {
     try {
@@ -17084,7 +17084,7 @@ function expandAllTracks() {
 // ---------------------------------------------------------------------------
 
 /**
- * setLabelPreferences — Set all label color names.
+ * setLabelPreferences - Set all label color names.
  */
 function setLabelPreferences(labels) {
     try {
@@ -17112,7 +17112,7 @@ function setLabelPreferences(labels) {
 }
 
 /**
- * getActiveLabelFilter — Get active label filter in project panel.
+ * getActiveLabelFilter - Get active label filter in project panel.
  */
 function getActiveLabelFilter() {
     try {
@@ -17131,7 +17131,7 @@ function getActiveLabelFilter() {
 }
 
 /**
- * setLabelFilter — Filter project panel by label color.
+ * setLabelFilter - Filter project panel by label color.
  */
 function setLabelFilter(colorIndex) {
     try {
@@ -17147,7 +17147,7 @@ function setLabelFilter(colorIndex) {
 }
 
 /**
- * clearLabelFilter — Clear label filter.
+ * clearLabelFilter - Clear label filter.
  */
 function clearLabelFilter() {
     try {
@@ -17164,7 +17164,7 @@ function clearLabelFilter() {
 // Note: setTimeDisplayFormat (item 20) already exists above in the preferences section.
 
 /**
- * setAudioWaveformDisplay — Show/hide audio waveforms on timeline.
+ * setAudioWaveformDisplay - Show/hide audio waveforms on timeline.
  */
 function setAudioWaveformDisplay(enabled) {
     try {
@@ -17180,7 +17180,7 @@ function setAudioWaveformDisplay(enabled) {
 }
 
 /**
- * setVideoThumbnailDisplay — Show/hide video thumbnails on timeline.
+ * setVideoThumbnailDisplay - Show/hide video thumbnails on timeline.
  */
 function setVideoThumbnailDisplay(enabled) {
     try {
@@ -17196,7 +17196,7 @@ function setVideoThumbnailDisplay(enabled) {
 }
 
 /**
- * setTrackNameDisplay — Show/hide track names.
+ * setTrackNameDisplay - Show/hide track names.
  */
 function setTrackNameDisplay(enabled) {
     try {
@@ -17216,7 +17216,7 @@ function setTrackNameDisplay(enabled) {
 // ---------------------------------------------------------------------------
 
 /**
- * showAlert — Show alert dialog.
+ * showAlert - Show alert dialog.
  */
 function showAlert(title, message) {
     try {
@@ -17228,7 +17228,7 @@ function showAlert(title, message) {
 }
 
 /**
- * showConfirmDialog — Show confirm dialog (yes/no).
+ * showConfirmDialog - Show confirm dialog (yes/no).
  */
 function showConfirmDialog(title, message) {
     try {
@@ -17240,7 +17240,7 @@ function showConfirmDialog(title, message) {
 }
 
 /**
- * showInputDialog — Show input dialog.
+ * showInputDialog - Show input dialog.
  */
 function showInputDialog(title, promptText, defaultValue) {
     try {
@@ -17256,7 +17256,7 @@ function showInputDialog(title, promptText, defaultValue) {
 }
 
 /**
- * showProgressDialog — Show progress dialog.
+ * showProgressDialog - Show progress dialog.
  */
 function showProgressDialog(title, message, progress) {
     try {
@@ -17281,7 +17281,7 @@ function showProgressDialog(title, message, progress) {
 }
 
 /**
- * writeToConsole — Write to ExtendScript console.
+ * writeToConsole - Write to ExtendScript console.
  */
 function writeToConsole(message) {
     try {
@@ -17296,7 +17296,7 @@ function writeToConsole(message) {
 // ---------------------------------------------------------------------------
 
 /**
- * getUIScaling — Get current UI scaling factor.
+ * getUIScaling - Get current UI scaling factor.
  */
 function getUIScaling() {
     try {
@@ -17326,7 +17326,7 @@ function getUIScaling() {
 }
 
 /**
- * setHighContrastMode — Toggle high contrast mode.
+ * setHighContrastMode - Toggle high contrast mode.
  */
 function setHighContrastMode(enabled) {
     try {
@@ -17350,7 +17350,7 @@ function setHighContrastMode(enabled) {
 // ============================================================================
 
 /**
- * assembleFromEDL — Assemble timeline from EDL JSON.
+ * assembleFromEDL - Assemble timeline from EDL JSON.
  * edlJson: JSON string with {clips:[{file,inPoint,outPoint,trackIndex,position,transitionName,transitionDuration},...]}
  */
 function assembleFromEDL(edlJson) {
@@ -17400,7 +17400,7 @@ function assembleFromEDL(edlJson) {
 }
 
 /**
- * assembleFromCSV — Assemble timeline from CSV file.
+ * assembleFromCSV - Assemble timeline from CSV file.
  * Columns: file, in, out, track, position
  */
 function assembleFromCSV(csvPath) {
@@ -17443,7 +17443,7 @@ function assembleFromCSV(csvPath) {
 }
 
 /**
- * assembleFromFolderOrder — Assemble clips from folder in filename order.
+ * assembleFromFolderOrder - Assemble clips from folder in filename order.
  */
 function assembleFromFolderOrder(folderPath, transitionName, transitionDuration) {
     try {
@@ -17482,7 +17482,7 @@ function assembleFromFolderOrder(folderPath, transitionName, transitionDuration)
 }
 
 /**
- * interleaveClips — Interleave clips from two tracks onto a destination arrangement.
+ * interleaveClips - Interleave clips from two tracks onto a destination arrangement.
  */
 function interleaveClips(trackIndexA, trackIndexB, transitionDuration) {
     try {
@@ -17514,7 +17514,7 @@ function interleaveClips(trackIndexA, trackIndexB, transitionDuration) {
 }
 
 /**
- * shuffleClips — Randomly shuffle clip order on a track.
+ * shuffleClips - Randomly shuffle clip order on a track.
  */
 function shuffleClips(trackType, trackIndex) {
     try {
@@ -17540,7 +17540,7 @@ function shuffleClips(trackType, trackIndex) {
 }
 
 /**
- * sortClipsByDuration — Sort clips by duration on a track.
+ * sortClipsByDuration - Sort clips by duration on a track.
  */
 function sortClipsByDuration(trackType, trackIndex, ascending) {
     try {
@@ -17563,7 +17563,7 @@ function sortClipsByDuration(trackType, trackIndex, ascending) {
 }
 
 /**
- * sortClipsByName — Sort clips alphabetically by clip name.
+ * sortClipsByName - Sort clips alphabetically by clip name.
  */
 function sortClipsByName(trackType, trackIndex, ascending) {
     try {
@@ -17591,7 +17591,7 @@ function sortClipsByName(trackType, trackIndex, ascending) {
 }
 
 /**
- * sortClipsByFileName — Sort clips by source file name.
+ * sortClipsByFileName - Sort clips by source file name.
  */
 function sortClipsByFileName(trackType, trackIndex, ascending) {
     try {
@@ -17623,7 +17623,7 @@ function sortClipsByFileName(trackType, trackIndex, ascending) {
 }
 
 /**
- * reverseClipOrder — Reverse order of clips on a track.
+ * reverseClipOrder - Reverse order of clips on a track.
  */
 function reverseClipOrder(trackType, trackIndex) {
     try {
@@ -17645,7 +17645,7 @@ function reverseClipOrder(trackType, trackIndex) {
 }
 
 /**
- * distributeClipsEvenly — Distribute clips evenly over a total duration.
+ * distributeClipsEvenly - Distribute clips evenly over a total duration.
  */
 function distributeClipsEvenly(trackType, trackIndex, totalDuration) {
     try {
@@ -17677,7 +17677,7 @@ function distributeClipsEvenly(trackType, trackIndex, totalDuration) {
 }
 
 /**
- * stackClips — Remove gaps, stack all clips from a start time.
+ * stackClips - Remove gaps, stack all clips from a start time.
  */
 function stackClips(trackType, trackIndex, startTime) {
     try {
@@ -17705,7 +17705,7 @@ function stackClips(trackType, trackIndex, startTime) {
 }
 
 /**
- * createOverlayTrack — Create overlay from one track over another with opacity and blend mode.
+ * createOverlayTrack - Create overlay from one track over another with opacity and blend mode.
  */
 function createOverlayTrack(sourceTrack, destTrack, opacity, blendMode) {
     try {
@@ -17731,7 +17731,7 @@ function createOverlayTrack(sourceTrack, destTrack, opacity, blendMode) {
 }
 
 /**
- * createGreenScreenComposite — Chroma key composite of foreground over background.
+ * createGreenScreenComposite - Chroma key composite of foreground over background.
  */
 function createGreenScreenComposite(fgTrackIndex, fgClipIndex, bgTrackIndex, bgClipIndex, keyColor) {
     try {
@@ -17756,7 +17756,7 @@ function createGreenScreenComposite(fgTrackIndex, fgClipIndex, bgTrackIndex, bgC
 }
 
 /**
- * createPictureInPictureGrid — Multi-source PIP grid layout.
+ * createPictureInPictureGrid - Multi-source PIP grid layout.
  */
 function createPictureInPictureGrid(trackIndicesJSON, layout) {
     try {
@@ -17782,7 +17782,7 @@ function createPictureInPictureGrid(trackIndicesJSON, layout) {
 }
 
 /**
- * layerTracks — Layer multiple tracks with specified opacities.
+ * layerTracks - Layer multiple tracks with specified opacities.
  */
 function layerTracks(baseTrack, overlayTracksJSON, opacitiesJSON) {
     try {
@@ -17807,7 +17807,7 @@ function layerTracks(baseTrack, overlayTracksJSON, opacitiesJSON) {
 }
 
 /**
- * generateBlackClip — Generate a black video clip on the timeline.
+ * generateBlackClip - Generate a black video clip on the timeline.
  */
 function generateBlackClip(trackIndex, startTime, duration) {
     try {
@@ -17827,7 +17827,7 @@ function generateBlackClip(trackIndex, startTime, duration) {
 }
 
 /**
- * generateColorClip — Generate a solid color clip on the timeline.
+ * generateColorClip - Generate a solid color clip on the timeline.
  * color: hex string e.g. "#FF0000"
  */
 function generateColorClip(trackIndex, startTime, duration, color) {
@@ -17850,7 +17850,7 @@ function generateColorClip(trackIndex, startTime, duration, color) {
 }
 
 /**
- * generateGradientClip — Generate a gradient clip on the timeline.
+ * generateGradientClip - Generate a gradient clip on the timeline.
  */
 function generateGradientClip(trackIndex, startTime, duration, colorStart, colorEnd, direction) {
     try {
@@ -17869,7 +17869,7 @@ function generateGradientClip(trackIndex, startTime, duration, colorStart, color
 }
 
 /**
- * generateTestPattern — Generate a test pattern clip (bars, grid, checkerboard).
+ * generateTestPattern - Generate a test pattern clip (bars, grid, checkerboard).
  */
 function generateTestPattern(trackIndex, startTime, duration, pattern) {
     try {
@@ -17893,7 +17893,7 @@ function generateTestPattern(trackIndex, startTime, duration, pattern) {
 }
 
 /**
- * generateSilence — Generate a silent audio clip.
+ * generateSilence - Generate a silent audio clip.
  */
 function generateSilence(trackIndex, startTime, duration) {
     try {
@@ -17909,7 +17909,7 @@ function generateSilence(trackIndex, startTime, duration) {
 }
 
 /**
- * generateTone — Generate an audio tone (sine, square, sawtooth).
+ * generateTone - Generate an audio tone (sine, square, sawtooth).
  */
 function generateTone(trackIndex, startTime, duration, frequency, amplitude) {
     try {
@@ -17927,7 +17927,7 @@ function generateTone(trackIndex, startTime, duration, frequency, amplitude) {
 }
 
 /**
- * duplicateTimelineSection — Copy a section of timeline to another position.
+ * duplicateTimelineSection - Copy a section of timeline to another position.
  */
 function duplicateTimelineSection(startTime, endTime, destTime) {
     try {
@@ -17963,7 +17963,7 @@ function duplicateTimelineSection(startTime, endTime, destTime) {
 }
 
 /**
- * repeatTimelineSection — Repeat a section of timeline N times.
+ * repeatTimelineSection - Repeat a section of timeline N times.
  */
 function repeatTimelineSection(startTime, endTime, count) {
     try {
@@ -17984,7 +17984,7 @@ function repeatTimelineSection(startTime, endTime, count) {
 }
 
 /**
- * mirrorTimeline — Mirror/reverse the entire timeline.
+ * mirrorTimeline - Mirror/reverse the entire timeline.
  */
 function mirrorTimeline() {
     try {
@@ -18012,7 +18012,7 @@ function mirrorTimeline() {
 }
 
 /**
- * splitTimelineAtPlayhead — Split timeline into two sequences at playhead position.
+ * splitTimelineAtPlayhead - Split timeline into two sequences at playhead position.
  */
 function splitTimelineAtPlayhead() {
     try {
@@ -18056,7 +18056,7 @@ function splitTimelineAtPlayhead() {
 }
 
 /**
- * getTimelineGapReport — Detailed report of all gaps on the timeline.
+ * getTimelineGapReport - Detailed report of all gaps on the timeline.
  */
 function getTimelineGapReport() {
     try {
@@ -18091,7 +18091,7 @@ function getTimelineGapReport() {
 }
 
 /**
- * getTimelineConflictReport — Report overlapping clips.
+ * getTimelineConflictReport - Report overlapping clips.
  */
 function getTimelineConflictReport() {
     try {
@@ -18124,7 +18124,7 @@ function getTimelineConflictReport() {
 }
 
 /**
- * getTimelineEffectsReport — Report all effects used on timeline.
+ * getTimelineEffectsReport - Report all effects used on timeline.
  */
 function getTimelineEffectsReport() {
     try {
@@ -18161,7 +18161,7 @@ function getTimelineEffectsReport() {
 }
 
 /**
- * getTimelineDurationBreakdown — Duration breakdown by clip type/source.
+ * getTimelineDurationBreakdown - Duration breakdown by clip type/source.
  */
 function getTimelineDurationBreakdown() {
     try {
@@ -18197,7 +18197,7 @@ function getTimelineDurationBreakdown() {
 }
 
 /**
- * getTimelineTrackUsageReport — Report track usage (empty/used time per track).
+ * getTimelineTrackUsageReport - Report track usage (empty/used time per track).
  */
 function getTimelineTrackUsageReport() {
     try {
@@ -18231,7 +18231,7 @@ function getTimelineTrackUsageReport() {
 // ---------------------------------------------------------------------------
 
 /**
- * getExportSettingsForPreset — Get detailed encoding settings from an export preset file.
+ * getExportSettingsForPreset - Get detailed encoding settings from an export preset file.
  */
 function getExportSettingsForPreset(presetPath) {
     try {
@@ -18271,7 +18271,7 @@ function getExportSettingsForPreset(presetPath) {
 }
 
 /**
- * createCustomExportSettings — Create custom export settings object.
+ * createCustomExportSettings - Create custom export settings object.
  * @param {string} settingsJson - JSON with codec, bitrate, resolution, fps, audio fields.
  */
 function createCustomExportSettings(settingsJson) {
@@ -18294,7 +18294,7 @@ function createCustomExportSettings(settingsJson) {
 }
 
 /**
- * getAvailableCodecs — List all available video codecs (via exporter list).
+ * getAvailableCodecs - List all available video codecs (via exporter list).
  */
 function getAvailableCodecs() {
     try {
@@ -18321,7 +18321,7 @@ function getAvailableCodecs() {
 }
 
 /**
- * getAvailableAudioCodecs — List all available audio codecs.
+ * getAvailableAudioCodecs - List all available audio codecs.
  */
 function getAvailableAudioCodecs() {
     try {
@@ -18340,7 +18340,7 @@ function getAvailableAudioCodecs() {
 }
 
 /**
- * getAvailableContainers — List available container formats.
+ * getAvailableContainers - List available container formats.
  */
 function getAvailableContainers() {
     try {
@@ -18363,7 +18363,7 @@ function getAvailableContainers() {
 // ---------------------------------------------------------------------------
 
 /**
- * convertToProRes — Convert a project item to Apple ProRes.
+ * convertToProRes - Convert a project item to Apple ProRes.
  * @param {number} projectItemIndex - Zero-based project item index.
  * @param {string} variant - ProRes variant: "422", "4444", "LT", "Proxy".
  * @param {string} outputPath - Output file path.
@@ -18402,7 +18402,7 @@ function convertToProRes(projectItemIndex, variant, outputPath) {
 }
 
 /**
- * convertToH264 — Convert a project item to H.264.
+ * convertToH264 - Convert a project item to H.264.
  */
 function convertToH264(projectItemIndex, outputPath, bitrate) {
     try {
@@ -18431,7 +18431,7 @@ function convertToH264(projectItemIndex, outputPath, bitrate) {
 }
 
 /**
- * convertToH265 — Convert a project item to H.265/HEVC.
+ * convertToH265 - Convert a project item to H.265/HEVC.
  */
 function convertToH265(projectItemIndex, outputPath, bitrate) {
     try {
@@ -18460,7 +18460,7 @@ function convertToH265(projectItemIndex, outputPath, bitrate) {
 }
 
 /**
- * convertToDNxHR — Convert a project item to DNxHR.
+ * convertToDNxHR - Convert a project item to DNxHR.
  * @param {string} profile - DNxHR profile: "LB", "SQ", "HQ", "HQX", "444".
  */
 function convertToDNxHR(projectItemIndex, outputPath, profile) {
@@ -18494,7 +18494,7 @@ function convertToDNxHR(projectItemIndex, outputPath, profile) {
 }
 
 /**
- * convertToGIF — Export a sequence as an animated GIF.
+ * convertToGIF - Export a sequence as an animated GIF.
  */
 function convertToGIF(sequenceIndex, outputPath, width, fps) {
     try {
@@ -18528,7 +18528,7 @@ function convertToGIF(sequenceIndex, outputPath, width, fps) {
 // ---------------------------------------------------------------------------
 
 /**
- * generateClipThumbnail — Generate a thumbnail image from a clip at a given time offset.
+ * generateClipThumbnail - Generate a thumbnail image from a clip at a given time offset.
  */
 function generateClipThumbnail(projectItemIndex, timeOffset, outputPath) {
     try {
@@ -18558,7 +18558,7 @@ function generateClipThumbnail(projectItemIndex, timeOffset, outputPath) {
 }
 
 /**
- * generateSequenceThumbnail — Generate a thumbnail image from a sequence at a given time.
+ * generateSequenceThumbnail - Generate a thumbnail image from a sequence at a given time.
  */
 function generateSequenceThumbnail(sequenceIndex, timeOffset, outputPath) {
     try {
@@ -18586,7 +18586,7 @@ function generateSequenceThumbnail(sequenceIndex, timeOffset, outputPath) {
 }
 
 /**
- * generateContactSheet — Generate a contact sheet (grid of thumbnails) from a clip.
+ * generateContactSheet - Generate a contact sheet (grid of thumbnails) from a clip.
  */
 function generateContactSheet(projectItemIndex, outputPath, cols, rows) {
     try {
@@ -18626,7 +18626,7 @@ function generateContactSheet(projectItemIndex, outputPath, cols, rows) {
 }
 
 /**
- * generateStoryboard — Generate storyboard frames from a sequence at regular intervals.
+ * generateStoryboard - Generate storyboard frames from a sequence at regular intervals.
  */
 function generateStoryboard(sequenceIndex, outputPath, interval) {
     try {
@@ -18671,7 +18671,7 @@ function generateStoryboard(sequenceIndex, outputPath, interval) {
 // ---------------------------------------------------------------------------
 
 /**
- * analyzeMediaCodec — Detailed codec analysis for a project item.
+ * analyzeMediaCodec - Detailed codec analysis for a project item.
  */
 function analyzeMediaCodec(projectItemIndex) {
     try {
@@ -18727,7 +18727,7 @@ function analyzeMediaCodec(projectItemIndex) {
 }
 
 /**
- * compareMediaSpecs — Compare specs of two project items.
+ * compareMediaSpecs - Compare specs of two project items.
  */
 function compareMediaSpecs(itemIndex1, itemIndex2) {
     try {
@@ -18769,7 +18769,7 @@ function compareMediaSpecs(itemIndex1, itemIndex2) {
 }
 
 /**
- * getBitRateInfo — Get bitrate information for a project item.
+ * getBitRateInfo - Get bitrate information for a project item.
  */
 function getBitRateInfo(projectItemIndex) {
     try {
@@ -18817,7 +18817,7 @@ function getBitRateInfo(projectItemIndex) {
 }
 
 /**
- * getColorDepthInfo — Get color depth and chroma subsampling for a project item.
+ * getColorDepthInfo - Get color depth and chroma subsampling for a project item.
  */
 function getColorDepthInfo(projectItemIndex) {
     try {
@@ -18856,7 +18856,7 @@ function getColorDepthInfo(projectItemIndex) {
 }
 
 /**
- * getAudioSpecsDetailed — Detailed audio specs for a project item.
+ * getAudioSpecsDetailed - Detailed audio specs for a project item.
  */
 function getAudioSpecsDetailed(projectItemIndex) {
     try {
@@ -18899,7 +18899,7 @@ function getAudioSpecsDetailed(projectItemIndex) {
 }
 
 /**
- * isVariableFrameRate — Check if a clip has variable frame rate.
+ * isVariableFrameRate - Check if a clip has variable frame rate.
  */
 function isVariableFrameRate(projectItemIndex) {
     try {
@@ -18937,7 +18937,7 @@ function isVariableFrameRate(projectItemIndex) {
 // ---------------------------------------------------------------------------
 
 /**
- * getFileHash — Get a file hash for a project item's media file.
+ * getFileHash - Get a file hash for a project item's media file.
  * Note: ExtendScript lacks native crypto; this does a basic checksum.
  */
 function getFileHash(projectItemIndex, algorithm) {
@@ -18969,7 +18969,7 @@ function getFileHash(projectItemIndex, algorithm) {
 }
 
 /**
- * getFileDates — Get creation/modification dates for a project item's media file.
+ * getFileDates - Get creation/modification dates for a project item's media file.
  */
 function getFileDates(projectItemIndex) {
     try {
@@ -18994,7 +18994,7 @@ function getFileDates(projectItemIndex) {
 }
 
 /**
- * moveMediaFile — Move media file to a new directory and relink in project.
+ * moveMediaFile - Move media file to a new directory and relink in project.
  */
 function moveMediaFile(projectItemIndex, newDirectory) {
     try {
@@ -19031,7 +19031,7 @@ function moveMediaFile(projectItemIndex, newDirectory) {
 }
 
 /**
- * copyMediaFile — Copy a project item's media file to a destination directory.
+ * copyMediaFile - Copy a project item's media file to a destination directory.
  */
 function copyMediaFile(projectItemIndex, destDirectory) {
     try {
@@ -19063,7 +19063,7 @@ function copyMediaFile(projectItemIndex, destDirectory) {
 }
 
 /**
- * renameMediaFile — Rename a media file on disk and relink in the project.
+ * renameMediaFile - Rename a media file on disk and relink in the project.
  */
 function renameMediaFile(projectItemIndex, newName) {
     try {
@@ -19106,7 +19106,7 @@ function renameMediaFile(projectItemIndex, newName) {
 // ---------------------------------------------------------------------------
 
 /**
- * addToRenderQueue — Add a sequence to Premiere Pro's internal render queue.
+ * addToRenderQueue - Add a sequence to Premiere Pro's internal render queue.
  */
 function addToRenderQueue(sequenceIndex, presetPath, outputPath) {
     try {
@@ -19138,7 +19138,7 @@ function addToRenderQueue(sequenceIndex, presetPath, outputPath) {
 }
 
 /**
- * getRenderQueueStatus — Get the current render queue status.
+ * getRenderQueueStatus - Get the current render queue status.
  */
 function getRenderQueueStatus() {
     try {
@@ -19158,7 +19158,7 @@ function getRenderQueueStatus() {
 }
 
 /**
- * clearRenderQueue — Clear the render queue.
+ * clearRenderQueue - Clear the render queue.
  */
 function clearRenderQueue() {
     try {
@@ -19172,7 +19172,7 @@ function clearRenderQueue() {
 }
 
 /**
- * pauseRenderQueue — Pause rendering.
+ * pauseRenderQueue - Pause rendering.
  */
 function pauseRenderQueue() {
     try {
@@ -19184,7 +19184,7 @@ function pauseRenderQueue() {
 }
 
 /**
- * resumeRenderQueue — Resume rendering.
+ * resumeRenderQueue - Resume rendering.
  */
 function resumeRenderQueue() {
     try {
@@ -21980,7 +21980,7 @@ function createApprovalPackage(sequenceIndex, outputDir) {
         var rpt = "=== APPROVAL PACKAGE ===\nSequence: "+seq.name+"\nDate: "+new Date().toISOString()+"\nDuration: "+dur.toFixed(2)+"s\nClips: "+tc+"\n";
         var folder = new Folder(pkgDir); folder.create();
         var rf = new File(pkg.reportPath); rf.open("w"); rf.write(rpt); rf.close();
-        return _ok({ sequence: seq.name, package: pkg, duration: dur, clipCount: tc });
+        return _ok({ sequence: seq.name, "package": pkg, duration: dur, clipCount: tc });
     } catch (e) { return _err("createApprovalPackage failed: " + e.message); }
 }
 
@@ -22831,7 +22831,7 @@ function setTimelineViewExtents(startSeconds, endSeconds) {
 // ---------------------------------------------------------------------------
 
 /**
- * getClipCameraInfo — Get camera metadata (make, model, lens, ISO, shutter, aperture)
+ * getClipCameraInfo - Get camera metadata (make, model, lens, ISO, shutter, aperture)
  * from XMP metadata embedded in the media file.
  */
 function getClipCameraInfo(projectItemIndex) {
@@ -22869,7 +22869,7 @@ function getClipCameraInfo(projectItemIndex) {
 }
 
 /**
- * getClipGPSInfo — Get GPS coordinates from XMP metadata.
+ * getClipGPSInfo - Get GPS coordinates from XMP metadata.
  */
 function getClipGPSInfo(projectItemIndex) {
     try {
@@ -22897,7 +22897,7 @@ function getClipGPSInfo(projectItemIndex) {
 }
 
 /**
- * getClipRecordDate — Get recording date/time from XMP metadata.
+ * getClipRecordDate - Get recording date/time from XMP metadata.
  */
 function getClipRecordDate(projectItemIndex) {
     try {
@@ -22923,7 +22923,7 @@ function getClipRecordDate(projectItemIndex) {
 }
 
 /**
- * sortClipsByRecordDate — Sort clips in a bin by recording date.
+ * sortClipsByRecordDate - Sort clips in a bin by recording date.
  * Reads XMP DateTimeOriginal/CreateDate and returns sorted order.
  */
 function sortClipsByRecordDate(binPath) {
@@ -22974,7 +22974,7 @@ function sortClipsByRecordDate(binPath) {
 }
 
 /**
- * groupClipsByCamera — Group clips by camera make/model into bins.
+ * groupClipsByCamera - Group clips by camera make/model into bins.
  * Creates sub-bins named after camera model and moves matching clips.
  */
 function groupClipsByCamera(binPath) {
@@ -23039,7 +23039,7 @@ function groupClipsByCamera(binPath) {
 // ---------------------------------------------------------------------------
 
 /**
- * markShotType — Mark a clip with a shot type using a marker (wide, medium, closeup, insert, cutaway).
+ * markShotType - Mark a clip with a shot type using a marker (wide, medium, closeup, insert, cutaway).
  */
 function markShotType(trackType, trackIndex, clipIndex, shotType) {
     try {
@@ -23068,7 +23068,7 @@ function markShotType(trackType, trackIndex, clipIndex, shotType) {
 }
 
 /**
- * getShotType — Get shot type marker from a clip.
+ * getShotType - Get shot type marker from a clip.
  */
 function getShotType(trackType, trackIndex, clipIndex) {
     try {
@@ -23095,7 +23095,7 @@ function getShotType(trackType, trackIndex, clipIndex) {
 }
 
 /**
- * filterByShotType — Get all clips in a sequence matching a specific shot type.
+ * filterByShotType - Get all clips in a sequence matching a specific shot type.
  */
 function filterByShotType(sequenceIndex, shotType) {
     try {
@@ -23130,7 +23130,7 @@ function filterByShotType(sequenceIndex, shotType) {
 }
 
 /**
- * createShotList — Export a shot list from a sequence to a file.
+ * createShotList - Export a shot list from a sequence to a file.
  */
 function createShotList(sequenceIndex, outputPath) {
     try {
@@ -23186,7 +23186,7 @@ function createShotList(sequenceIndex, outputPath) {
 }
 
 /**
- * importShotList — Import a shot list from CSV and apply shot types to timeline clips.
+ * importShotList - Import a shot list from CSV and apply shot types to timeline clips.
  */
 function importShotList(csvPath, sequenceIndex) {
     try {
@@ -23246,7 +23246,7 @@ function importShotList(csvPath, sequenceIndex) {
 // ---------------------------------------------------------------------------
 
 /**
- * markScene — Mark a clip with a scene number using a marker.
+ * markScene - Mark a clip with a scene number using a marker.
  */
 function markScene(trackType, trackIndex, clipIndex, sceneNumber) {
     try {
@@ -23275,7 +23275,7 @@ function markScene(trackType, trackIndex, clipIndex, sceneNumber) {
 }
 
 /**
- * markTake — Mark a clip with a take number using a marker.
+ * markTake - Mark a clip with a take number using a marker.
  */
 function markTake(trackType, trackIndex, clipIndex, takeNumber) {
     try {
@@ -23304,7 +23304,7 @@ function markTake(trackType, trackIndex, clipIndex, takeNumber) {
 }
 
 /**
- * getBestTake — Get the longest/marked-best take for a scene number across all tracks.
+ * getBestTake - Get the longest/marked-best take for a scene number across all tracks.
  */
 function getBestTake(sceneNumber) {
     try {
@@ -23344,7 +23344,7 @@ function getBestTake(sceneNumber) {
 }
 
 /**
- * organizeByScenesAndTakes — Auto-organize project items by parsing scene/take from filenames.
+ * organizeByScenesAndTakes - Auto-organize project items by parsing scene/take from filenames.
  * Expected naming: S01T01_*, Scene1_Take2_*, etc.
  */
 function organizeByScenesAndTakes() {
@@ -23400,7 +23400,7 @@ function organizeByScenesAndTakes() {
 }
 
 /**
- * getSceneList — Get all scenes with their takes from the active sequence.
+ * getSceneList - Get all scenes with their takes from the active sequence.
  */
 function getSceneList() {
     try {
@@ -23447,7 +23447,7 @@ function getSceneList() {
 // ---------------------------------------------------------------------------
 
 /**
- * matchCameraSettings — Compare camera settings between two project items.
+ * matchCameraSettings - Compare camera settings between two project items.
  */
 function matchCameraSettings(clip1Index, clip2Index) {
     try {
@@ -23498,7 +23498,7 @@ function matchCameraSettings(clip1Index, clip2Index) {
 }
 
 /**
- * findClipsFromSameCamera — Find all clips shot with the same camera as the given clip.
+ * findClipsFromSameCamera - Find all clips shot with the same camera as the given clip.
  */
 function findClipsFromSameCamera(projectItemIndex) {
     try {
@@ -23549,7 +23549,7 @@ function findClipsFromSameCamera(projectItemIndex) {
 }
 
 /**
- * createMulticamByCamera — Create a multicam sequence grouping clips by camera make/model.
+ * createMulticamByCamera - Create a multicam sequence grouping clips by camera make/model.
  */
 function createMulticamByCamera(outputName) {
     try {
@@ -23607,7 +23607,7 @@ function createMulticamByCamera(outputName) {
 // ---------------------------------------------------------------------------
 
 /**
- * getSourceTimecode — Get original source timecode from a project item.
+ * getSourceTimecode - Get original source timecode from a project item.
  */
 function getSourceTimecode(projectItemIndex) {
     try {
@@ -23642,7 +23642,7 @@ function getSourceTimecode(projectItemIndex) {
 }
 
 /**
- * setSourceTimecodeOffset — Set source timecode offset on a project item via XMP.
+ * setSourceTimecodeOffset - Set source timecode offset on a project item via XMP.
  */
 function setSourceTimecodeOffset(projectItemIndex, offset) {
     try {
@@ -23662,7 +23662,7 @@ function setSourceTimecodeOffset(projectItemIndex, offset) {
 }
 
 /**
- * syncByTimecode — Sync clips across specified tracks by aligning their source timecodes.
+ * syncByTimecode - Sync clips across specified tracks by aligning their source timecodes.
  */
 function syncByTimecode(trackIndicesJson) {
     try {
@@ -23702,7 +23702,7 @@ function syncByTimecode(trackIndicesJson) {
 }
 
 /**
- * findTimecodeBreaks — Find gaps in timecode continuity on a track.
+ * findTimecodeBreaks - Find gaps in timecode continuity on a track.
  */
 function findTimecodeBreaks(trackType, trackIndex) {
     try {
@@ -23741,7 +23741,7 @@ function findTimecodeBreaks(trackType, trackIndex) {
 // ---------------------------------------------------------------------------
 
 /**
- * rateClip — Rate a clip (1-5 stars) by setting XMP rating metadata.
+ * rateClip - Rate a clip (1-5 stars) by setting XMP rating metadata.
  */
 function rateClip(projectItemIndex, rating) {
     try {
@@ -23762,7 +23762,7 @@ function rateClip(projectItemIndex, rating) {
 }
 
 /**
- * getClipRating — Get clip rating from XMP metadata.
+ * getClipRating - Get clip rating from XMP metadata.
  */
 function getClipRating(projectItemIndex) {
     try {
@@ -23785,7 +23785,7 @@ function getClipRating(projectItemIndex) {
 }
 
 /**
- * filterByRating — Get all project items with rating >= minRating.
+ * filterByRating - Get all project items with rating >= minRating.
  */
 function filterByRating(minRating) {
     try {
@@ -23816,7 +23816,7 @@ function filterByRating(minRating) {
 }
 
 /**
- * getTopRatedClips — Get top N rated clips, sorted by rating descending.
+ * getTopRatedClips - Get top N rated clips, sorted by rating descending.
  */
 function getTopRatedClips(count) {
     try {
@@ -23854,7 +23854,7 @@ function getTopRatedClips(count) {
 // ---------------------------------------------------------------------------
 
 /**
- * setClipNote — Set a text note on a project item via XMP dc:description.
+ * setClipNote - Set a text note on a project item via XMP dc:description.
  */
 function setClipNote(projectItemIndex, note) {
     try {
@@ -23874,7 +23874,7 @@ function setClipNote(projectItemIndex, note) {
 }
 
 /**
- * getClipNote — Get clip note from XMP dc:description.
+ * getClipNote - Get clip note from XMP dc:description.
  */
 function getClipNote(projectItemIndex) {
     try {
@@ -23896,7 +23896,7 @@ function getClipNote(projectItemIndex) {
 }
 
 /**
- * searchClipNotes — Search all clip notes for a text string.
+ * searchClipNotes - Search all clip notes for a text string.
  */
 function searchClipNotes(searchText) {
     try {
@@ -23926,7 +23926,7 @@ function searchClipNotes(searchText) {
 }
 
 /**
- * exportClipNotes — Export all clip notes as CSV or JSON to a file.
+ * exportClipNotes - Export all clip notes as CSV or JSON to a file.
  */
 function exportClipNotes(outputPath, format) {
     try {
@@ -23982,7 +23982,7 @@ function exportClipNotes(outputPath, format) {
 // ---------------------------------------------------------------------------
 
 /**
- * 1. snapshotTimeline(sequenceIndex) — Create a JSON snapshot of timeline state.
+ * 1. snapshotTimeline(sequenceIndex) - Create a JSON snapshot of timeline state.
  */
 function snapshotTimeline(sequenceIndex) {
     try {
@@ -24042,7 +24042,7 @@ function snapshotTimeline(sequenceIndex) {
 }
 
 /**
- * 2. compareTimelineSnapshots(snapshot1Json, snapshot2Json) — Diff two timeline snapshots.
+ * 2. compareTimelineSnapshots(snapshot1Json, snapshot2Json) - Diff two timeline snapshots.
  */
 function compareTimelineSnapshots(snapshot1Json, snapshot2Json) {
     try {
@@ -24104,7 +24104,7 @@ function compareTimelineSnapshots(snapshot1Json, snapshot2Json) {
 }
 
 /**
- * 3. getTimelineChanges(sequenceIndex, sinceTimestamp) — Get changes since timestamp.
+ * 3. getTimelineChanges(sequenceIndex, sinceTimestamp) - Get changes since timestamp.
  */
 function getTimelineChanges(sequenceIndex, sinceTimestamp) {
     try {
@@ -24124,7 +24124,7 @@ function getTimelineChanges(sequenceIndex, sinceTimestamp) {
 }
 
 /**
- * 4. highlightChangedClips(sequenceIndex, changedClipIds) — Select/highlight changed clips.
+ * 4. highlightChangedClips(sequenceIndex, changedClipIds) - Select/highlight changed clips.
  */
 function highlightChangedClips(sequenceIndex, changedClipIds) {
     try {
@@ -24155,7 +24155,7 @@ function highlightChangedClips(sequenceIndex, changedClipIds) {
 }
 
 /**
- * 5. revertClipToSnapshot(trackType, trackIndex, clipIndex, snapshotJson) — Revert clip to snapshot state.
+ * 5. revertClipToSnapshot(trackType, trackIndex, clipIndex, snapshotJson) - Revert clip to snapshot state.
  */
 function revertClipToSnapshot(trackType, trackIndex, clipIndex, snapshotJson) {
     try {
@@ -24200,7 +24200,7 @@ function revertClipToSnapshot(trackType, trackIndex, clipIndex, snapshotJson) {
 // ---------------------------------------------------------------------------
 
 /**
- * 6. saveSequenceVersion(sequenceIndex, versionName, notes) — Save named version.
+ * 6. saveSequenceVersion(sequenceIndex, versionName, notes) - Save named version.
  */
 function saveSequenceVersion(sequenceIndex, versionName, notes) {
     try {
@@ -24228,7 +24228,7 @@ function saveSequenceVersion(sequenceIndex, versionName, notes) {
 }
 
 /**
- * 7. listSequenceVersions(sequenceIndex) — List all saved versions.
+ * 7. listSequenceVersions(sequenceIndex) - List all saved versions.
  */
 function listSequenceVersions(sequenceIndex) {
     try {
@@ -24263,7 +24263,7 @@ function listSequenceVersions(sequenceIndex) {
 }
 
 /**
- * 8. loadSequenceVersion(sequenceIndex, versionName) — Load a saved version.
+ * 8. loadSequenceVersion(sequenceIndex, versionName) - Load a saved version.
  */
 function loadSequenceVersion(sequenceIndex, versionName) {
     try {
@@ -24291,7 +24291,7 @@ function loadSequenceVersion(sequenceIndex, versionName) {
 }
 
 /**
- * 9. deleteSequenceVersion(sequenceIndex, versionName) — Delete a version.
+ * 9. deleteSequenceVersion(sequenceIndex, versionName) - Delete a version.
  */
 function deleteSequenceVersion(sequenceIndex, versionName) {
     try {
@@ -24310,7 +24310,7 @@ function deleteSequenceVersion(sequenceIndex, versionName) {
 }
 
 /**
- * 10. mergeSequenceVersions(baseVersion, overlayVersion, strategy) — Merge two versions.
+ * 10. mergeSequenceVersions(baseVersion, overlayVersion, strategy) - Merge two versions.
  */
 function mergeSequenceVersions(baseVersion, overlayVersion, strategy) {
     try {
@@ -24373,7 +24373,7 @@ function mergeSequenceVersions(baseVersion, overlayVersion, strategy) {
 // ---------------------------------------------------------------------------
 
 /**
- * 11. createABComparison(seqIndexA, seqIndexB) — Set up side-by-side comparison.
+ * 11. createABComparison(seqIndexA, seqIndexB) - Set up side-by-side comparison.
  */
 function createABComparison(seqIndexA, seqIndexB) {
     try {
@@ -24400,7 +24400,7 @@ function createABComparison(seqIndexA, seqIndexB) {
 }
 
 /**
- * 12. switchABView(view) — Switch between A, B, or split view.
+ * 12. switchABView(view) - Switch between A, B, or split view.
  */
 function switchABView(view) {
     try {
@@ -24416,7 +24416,7 @@ function switchABView(view) {
 }
 
 /**
- * 13. getABDifferences(seqIndexA, seqIndexB) — List differences between A and B.
+ * 13. getABDifferences(seqIndexA, seqIndexB) - List differences between A and B.
  */
 function getABDifferences(seqIndexA, seqIndexB) {
     try {
@@ -24435,7 +24435,7 @@ function getABDifferences(seqIndexA, seqIndexB) {
 // ---------------------------------------------------------------------------
 
 /**
- * 14. getClipboardContents() — Get clipboard contents info.
+ * 14. getClipboardContents() - Get clipboard contents info.
  */
 function getClipboardContents() {
     try {
@@ -24458,7 +24458,7 @@ function getClipboardContents() {
 }
 
 /**
- * 15. clearClipboard() — Clear editing clipboard.
+ * 15. clearClipboard() - Clear editing clipboard.
  */
 function clearClipboard() {
     try {
@@ -24483,7 +24483,7 @@ function clearClipboard() {
 }
 
 /**
- * 16. clipboardHasContent() — Check if clipboard has content.
+ * 16. clipboardHasContent() - Check if clipboard has content.
  */
 function clipboardHasContent() {
     try {
@@ -24502,7 +24502,7 @@ function clipboardHasContent() {
 // ---------------------------------------------------------------------------
 
 /**
- * 17. getUndoHistory(count) — Get undo history entries.
+ * 17. getUndoHistory(count) - Get undo history entries.
  */
 function getUndoHistory(count) {
     try {
@@ -24520,7 +24520,7 @@ function getUndoHistory(count) {
 }
 
 /**
- * 18. getUndoCount() — Get available undo count.
+ * 18. getUndoCount() - Get available undo count.
  */
 function getUndoCount() {
     try {
@@ -24537,7 +24537,7 @@ function getUndoCount() {
 }
 
 /**
- * 19. undoMultiple(count) — Undo multiple steps.
+ * 19. undoMultiple(count) - Undo multiple steps.
  */
 function undoMultiple(count) {
     try {
@@ -24557,7 +24557,7 @@ function undoMultiple(count) {
 }
 
 /**
- * 20. redoMultiple(count) — Redo multiple steps.
+ * 20. redoMultiple(count) - Redo multiple steps.
  */
 function redoMultiple(count) {
     try {
@@ -24581,7 +24581,7 @@ function redoMultiple(count) {
 // ---------------------------------------------------------------------------
 
 /**
- * 21. createProjectBackup(outputPath, includeMedia) — Create full project backup.
+ * 21. createProjectBackup(outputPath, includeMedia) - Create full project backup.
  */
 function createProjectBackup(outputPath, includeMedia) {
     try {
@@ -24632,7 +24632,7 @@ function createProjectBackup(outputPath, includeMedia) {
 }
 
 /**
- * 22. getAutoSaveVersions() — List auto-save versions.
+ * 22. getAutoSaveVersions() - List auto-save versions.
  */
 function getAutoSaveVersions() {
     try {
@@ -24659,7 +24659,7 @@ function getAutoSaveVersions() {
 }
 
 /**
- * 23. restoreAutoSave(versionPath) — Restore from auto-save.
+ * 23. restoreAutoSave(versionPath) - Restore from auto-save.
  */
 function restoreAutoSave(versionPath) {
     try {
@@ -24672,7 +24672,7 @@ function restoreAutoSave(versionPath) {
 }
 
 /**
- * 24. setAutoSaveNow() — Trigger immediate auto-save.
+ * 24. setAutoSaveNow() - Trigger immediate auto-save.
  */
 function setAutoSaveNow() {
     try {
@@ -24694,7 +24694,7 @@ function setAutoSaveNow() {
 }
 
 /**
- * 25. getBackupSchedule() — Get backup schedule info.
+ * 25. getBackupSchedule() - Get backup schedule info.
  */
 function getBackupSchedule() {
     try {
@@ -24733,7 +24733,7 @@ function getBackupSchedule() {
 // ---------------------------------------------------------------------------
 
 /**
- * 26. upgradeProjectVersion(projectPath) — Upgrade older project file.
+ * 26. upgradeProjectVersion(projectPath) - Upgrade older project file.
  */
 function upgradeProjectVersion(projectPath) {
     try {
@@ -24747,7 +24747,7 @@ function upgradeProjectVersion(projectPath) {
 }
 
 /**
- * 27. getProjectVersion(projectPath) — Get project file version.
+ * 27. getProjectVersion(projectPath) - Get project file version.
  */
 function getProjectVersion(projectPath) {
     try {
@@ -24779,7 +24779,7 @@ function getProjectVersion(projectPath) {
 }
 
 /**
- * 28. exportProjectForOlderVersion(outputPath, targetVersion) — Save for older Premiere Pro.
+ * 28. exportProjectForOlderVersion(outputPath, targetVersion) - Save for older Premiere Pro.
  */
 function exportProjectForOlderVersion(outputPath, targetVersion) {
     try {
@@ -24811,7 +24811,7 @@ function exportProjectForOlderVersion(outputPath, targetVersion) {
 }
 
 /**
- * 29. checkProjectCompatibility(projectPath) — Check compatibility with current version.
+ * 29. checkProjectCompatibility(projectPath) - Check compatibility with current version.
  */
 function checkProjectCompatibility(projectPath) {
     try {
@@ -24852,7 +24852,7 @@ function checkProjectCompatibility(projectPath) {
 }
 
 /**
- * 30. importProjectFromOtherNLE(sourcePath, sourceFormat) — Import from DaVinci/FCPX/Avid.
+ * 30. importProjectFromOtherNLE(sourcePath, sourceFormat) - Import from DaVinci/FCPX/Avid.
  */
 function importProjectFromOtherNLE(sourcePath, sourceFormat) {
     try {

--- a/cep-panel/src/host/premiere.jsx
+++ b/cep-panel/src/host/premiere.jsx
@@ -198,8 +198,17 @@ function createSequence(paramsJson) {
             return _err("No project is open");
         }
 
-        // Use the new sequence preset creation if available
-        var seqID = app.project.createNewSequence(name);
+        // createNewSequence takes (name, placeholderID). Called with one
+        // argument it creates nothing and returns undefined, so this reported
+        // "createNewSequence returned no ID" -- or, via the MCP layer, an empty
+        // result that looked like success. The ID only has to be unique.
+        //
+        // Note this API makes Premiere show its New Sequence dialog, so it is
+        // not usable unattended; that is Adobe's behaviour, not something we
+        // can suppress. For scripted use call createSequenceFromPreset, which
+        // goes through the QE DOM and does not prompt.
+        var placeholderID = name + "-" + new Date().getTime();
+        var seqID = app.project.createNewSequence(name, placeholderID);
 
         if (seqID) {
             // Try to set properties on the newly created sequence
@@ -12407,10 +12416,24 @@ function listSequencePresets() {
 }
 
 // 2. createSequenceFromPreset
-function createSequenceFromPreset(name, presetPath) {
+// Takes a JSON params object, not positional arguments: the panel's
+// evalCommand dispatcher builds `fnName(argsJsonString)`, so a positional
+// signature receives the whole JSON blob as the first parameter and undefined
+// for the rest -- which surfaced as "presetPath is required" on every call.
+// Accepts both preset_path (the MCP tool's snake_case field) and presetPath.
+function createSequenceFromPreset(paramsJson) {
     try {
+        var params = paramsJson;
+        if (typeof paramsJson === "string") {
+            try { params = JSON.parse(paramsJson); }
+            catch (parseErr) { return _err("Invalid params JSON: " + parseErr.message); }
+        }
+        params = params || {};
+        var name = params.name;
+        var presetPath = params.preset_path || params.presetPath;
+
         if (!name) return _err("name is required");
-        if (!presetPath) return _err("presetPath is required");
+        if (!presetPath) return _err("preset_path is required");
         if (!new File(presetPath).exists) return _err("Preset file not found: " + presetPath);
         if (!app.project) return _err("No project open");
         if (typeof qe !== "undefined" && qe.project) {

--- a/cep-panel/src/panel.js
+++ b/cep-panel/src/panel.js
@@ -42,9 +42,37 @@
     var serverPort = DEFAULT_PORT;
     var autoScroll = true;
 
+    /**
+     * Resolve a file inside the extension's src/host directory.
+     *
+     * __dirname is not reliable here: depending on the platform and how CEP
+     * loads panel.js it can point either at the extension root or at src/,
+     * so a fixed relative path silently resolves to a non-existent file and
+     * $.evalFile() fails with a bare "EvalScript error." Probe the known
+     * layouts instead and return the first that exists on disk.
+     */
+    function resolveHostPath(fileName) {
+        var extensionRoot = csInterface.getSystemPath(SystemPath.EXTENSION);
+        var candidates = [
+            path.join(__dirname, "host", fileName),
+            path.join(__dirname, "src", "host", fileName),
+            path.join(extensionRoot, "src", "host", fileName),
+            path.join(extensionRoot, "host", fileName)
+        ];
+        for (var i = 0; i < candidates.length; i++) {
+            try {
+                if (fs.existsSync(candidates[i])) {
+                    return candidates[i].replace(/\\/g, "/");
+                }
+            } catch (e) { /* keep probing */ }
+        }
+        // Nothing found — return the conventional path so the error names it.
+        return candidates[0].replace(/\\/g, "/");
+    }
+
     // Lazy-loading state for the full premiere.jsx ExtendScript library
     var premiereJsxLoaded = false;
-    var premiereJsxPath = path.join(__dirname, "host", "premiere.jsx").replace(/\\/g, "/");
+    var premiereJsxPath = resolveHostPath("premiere.jsx");
 
     // Stats tracking
     var stats = {
@@ -546,7 +574,7 @@
     // Load ExtendScript host functions
     // ---------------------------------------------------------------------------
     function loadHostScript() {
-        var corePath = path.join(__dirname, "host", "core.jsx").replace(/\\/g, "/");
+        var corePath = resolveHostPath("core.jsx");
         log("Loading core ExtendScript: " + corePath);
         csInterface.evalScript('$.evalFile("' + corePath + '")', function (result) {
             if (result === "EvalScript error.") {

--- a/scripts/install-cep-panel-win.bat
+++ b/scripts/install-cep-panel-win.bat
@@ -8,13 +8,10 @@ echo Installing CEP panel...
 REM Remove old installation
 if exist "%PANEL_DIR%" rmdir /s /q "%PANEL_DIR%"
 
-REM Create symlink (requires admin on older Windows, works normally on newer)
-mklink /D "%PANEL_DIR%" "%~dp0..\cep-panel"
-
-if errorlevel 1 (
-    echo Symlink failed. Copying files instead...
-    xcopy /E /I /Y "%~dp0..\cep-panel" "%PANEL_DIR%"
-)
+REM Copy files (not a symlink): Adobe CEP's signature verification fails on
+REM symlinked extension folders unless the host runs as admin - see
+REM https://github.com/Adobe-CEP/CEP-Resources/blob/master/ZXPSignCMD/KnownIssue2024.md
+xcopy /E /I /Y "%~dp0..\cep-panel" "%PANEL_DIR%"
 
 REM Enable unsigned extensions
 REG ADD "HKCU\Software\Adobe\CSXS.11" /v PlayerDebugMode /t REG_SZ /d 1 /f

--- a/scripts/launch-premiere-mcp.ps1
+++ b/scripts/launch-premiere-mcp.ps1
@@ -1,19 +1,23 @@
 <#
-    Launch Premiere Pro with the MCP bridge working, then start the backend
-    services.
+    Launch Premiere Pro with a project open, then start the backend services.
 
-    Why the cache gets deleted first: CEP decides whether an extension is
-    "Trusted" (i.e. may run unsigned under PlayerDebugMode) once, while it
-    registers extensions during Premiere startup. If a stale
-    cep_cache\PPRO_*_com.premierpro.mcp.bridge directory is present that
-    decision flips to a signature check, which an unsigned extension fails --
-    the log shows "Signature verification failed" and the panel is
-    unavailable for the whole session, including from the Extensions menu.
-    Clearing the cache before launch makes the load deterministic.
+    You usually do not need this script. Quitting Premiere normally and
+    reopening a project works on its own: the extension registers as Trusted,
+    the panel auto-starts (its manifest listens for ApplicationActivate) and
+    ts-bridge connects by itself. All this script really adds is doing those
+    steps in one command, plus one recovery step.
 
-    Once the extension loads as Trusted the panel auto-starts (its manifest
-    listens for ApplicationActivate) and ts-bridge reconnects on its own, so
-    no manual steps are needed.
+    The recovery step is clearing orphaned CEPHtmlEngine processes. If Premiere
+    is force-killed or crashes, its CEP host processes can survive; the next
+    launch then fails extension registration with "Signature verification
+    failed" and the panel is unavailable for the whole session -- including
+    from the Extensions menu, which is what makes it look intermittent. A
+    stale cep_cache directory is NOT the cause; verified by launching with the
+    cache intact and no orphans, which registers as Trusted every time.
+
+    A project must be open for the panel to stay alive: CEP unloads the
+    extension on the welcome screen, and ApplicationActivate only fires once
+    at startup, so there is no second auto-start. Hence -Project.
 #>
 
 [CmdletBinding()]
@@ -51,13 +55,13 @@ foreach ($v in 10, 11, 12, 13) {
     }
 }
 
-# --- 2. Premiere has to be closed for a cache clear to matter -------------
+# --- 2. Premiere must be closed: registration happens at startup ----------
 $running = Get-Process -Name 'Adobe Premiere Pro' -ErrorAction SilentlyContinue
 if ($running) {
     if (-not $Force) {
         Write-Warn 'Premiere Pro is already running.'
-        Write-Warn 'The extension load decision is made at startup, so quit Premiere'
-        Write-Warn 'and run this again (or pass -Force to close it for you).'
+        Write-Warn 'Extensions register at startup, so quit Premiere and run this'
+        Write-Warn 'again (or pass -Force to close it for you).'
         Write-Warn 'Save your work first -- Force does not prompt.'
         exit 1
     }
@@ -65,16 +69,19 @@ if ($running) {
     $running | Stop-Process -Force
     Start-Sleep -Seconds 3
 }
-Get-Process -Name 'CEPHtmlEngine' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
 
-# --- 3. Clear the stale CEP cache ----------------------------------------
-Write-Step 'Clearing stale CEP cache'
-Get-ChildItem "$env:LOCALAPPDATA\Temp\cep_cache" -Directory -ErrorAction SilentlyContinue |
-    Where-Object { $_.Name -like "*$extensionId*" } |
-    ForEach-Object {
-        Remove-Item -Recurse -Force $_.FullName -ErrorAction SilentlyContinue
-        Write-Warn "removed $($_.Name)"
-    }
+# --- 3. Clear orphaned CEP host processes ---------------------------------
+# This is the actual recovery step. Survivors of a crash or a force-kill make
+# the next launch fail extension registration.
+$orphans = Get-Process -Name 'CEPHtmlEngine' -ErrorAction SilentlyContinue
+if ($orphans) {
+    Write-Step "Clearing $($orphans.Count) orphaned CEPHtmlEngine process(es)"
+    $orphans | Stop-Process -Force -ErrorAction SilentlyContinue
+    Start-Sleep -Seconds 1
+}
+
+# The cache is left alone on purpose: it is not the cause, and deleting it
+# only forces the panel to rebuild it on the next launch.
 
 # --- 4. Launch Premiere and wait for the panel's WebSocket ---------------
 # Open a project along with Premiere where possible. The panel's manifest
@@ -112,11 +119,12 @@ if (-not $panelUp) {
     Write-Warn 'Panel did not come up within 3 minutes. In order of likelihood:'
     Write-Warn '  1. No project open -- open one, then Window > Extensions >'
     Write-Warn '     PremierPro MCP Bridge (auto-start only fires at launch).'
-    Write-Warn '  2. Panel opened but rendered blank -- close it, delete'
-    Write-Warn "     $env:LOCALAPPDATA\Temp\cep_cache\PPRO_*_$extensionId,"
-    Write-Warn '     then reopen it from that menu.'
-    Write-Warn "  3. Check $env:LOCALAPPDATA\Temp\CEP12-PPRO.log for"
-    Write-Warn '     "Signature verification failed" and rerun this script.'
+    Write-Warn "  2. Check $env:LOCALAPPDATA\Temp\CEP12-PPRO.log for"
+    Write-Warn '     "Signature verification failed". If present, quit Premiere,'
+    Write-Warn '     confirm no CEPHtmlEngine processes remain, and rerun.'
+    Write-Warn '  3. Panel opened but rendered blank -- close it and reopen it'
+    Write-Warn "     from that menu; if it persists, delete"
+    Write-Warn "     $env:LOCALAPPDATA\Temp\cep_cache\PPRO_*_$extensionId."
 } else {
     Write-Host '    Panel is listening on 9801.' -ForegroundColor Green
 }

--- a/scripts/launch-premiere-mcp.ps1
+++ b/scripts/launch-premiere-mcp.ps1
@@ -1,0 +1,131 @@
+<#
+    Launch Premiere Pro with the MCP bridge working, then start the backend
+    services.
+
+    Why the cache gets deleted first: CEP decides whether an extension is
+    "Trusted" (i.e. may run unsigned under PlayerDebugMode) once, while it
+    registers extensions during Premiere startup. If a stale
+    cep_cache\PPRO_*_com.premierpro.mcp.bridge directory is present that
+    decision flips to a signature check, which an unsigned extension fails --
+    the log shows "Signature verification failed" and the panel is
+    unavailable for the whole session, including from the Extensions menu.
+    Clearing the cache before launch makes the load deterministic.
+
+    Once the extension loads as Trusted the panel auto-starts (its manifest
+    listens for ApplicationActivate) and ts-bridge reconnects on its own, so
+    no manual steps are needed.
+#>
+
+[CmdletBinding()]
+param(
+    # Project to open. Strongly recommended: CEP unloads the extension while
+    # Premiere sits on the welcome screen, so the panel dies within seconds of
+    # starting if no project is open. Defaults to the last one used.
+    [string]$Project,
+    # Skip starting the rust/python/ts-bridge services.
+    [switch]$NoServices,
+    # Kill a running Premiere so the cache clear can take effect.
+    [switch]$Force
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot   = Split-Path -Parent $PSScriptRoot
+$premiere   = 'C:\Program Files\Adobe\Adobe Premiere Pro 2026\Adobe Premiere Pro.exe'
+$extensionId = 'com.premierpro.mcp.bridge'
+
+function Write-Step($msg) { Write-Host "==> $msg" -ForegroundColor Cyan }
+function Write-Warn($msg) { Write-Host "    $msg" -ForegroundColor Yellow }
+
+# --- 1. PlayerDebugMode must be a string, not a DWORD ---------------------
+# CEP reads this as REG_SZ on Windows; a DWORD is ignored and the extension
+# falls back to a signature check it cannot pass.
+Write-Step 'Checking PlayerDebugMode'
+foreach ($v in 10, 11, 12, 13) {
+    $key = "HKCU:\Software\Adobe\CSXS.$v"
+    if (-not (Test-Path $key)) { New-Item -Path $key -Force | Out-Null }
+    $existing = Get-ItemProperty -Path $key -Name PlayerDebugMode -ErrorAction SilentlyContinue
+    if ($null -eq $existing -or $existing.PlayerDebugMode -ne '1') {
+        Remove-ItemProperty -Path $key -Name PlayerDebugMode -ErrorAction SilentlyContinue
+        New-ItemProperty -Path $key -Name PlayerDebugMode -Value '1' -PropertyType String -Force | Out-Null
+        Write-Warn "CSXS.$v PlayerDebugMode set to REG_SZ 1"
+    }
+}
+
+# --- 2. Premiere has to be closed for a cache clear to matter -------------
+$running = Get-Process -Name 'Adobe Premiere Pro' -ErrorAction SilentlyContinue
+if ($running) {
+    if (-not $Force) {
+        Write-Warn 'Premiere Pro is already running.'
+        Write-Warn 'The extension load decision is made at startup, so quit Premiere'
+        Write-Warn 'and run this again (or pass -Force to close it for you).'
+        Write-Warn 'Save your work first -- Force does not prompt.'
+        exit 1
+    }
+    Write-Step 'Closing Premiere Pro (-Force)'
+    $running | Stop-Process -Force
+    Start-Sleep -Seconds 3
+}
+Get-Process -Name 'CEPHtmlEngine' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+
+# --- 3. Clear the stale CEP cache ----------------------------------------
+Write-Step 'Clearing stale CEP cache'
+Get-ChildItem "$env:LOCALAPPDATA\Temp\cep_cache" -Directory -ErrorAction SilentlyContinue |
+    Where-Object { $_.Name -like "*$extensionId*" } |
+    ForEach-Object {
+        Remove-Item -Recurse -Force $_.FullName -ErrorAction SilentlyContinue
+        Write-Warn "removed $($_.Name)"
+    }
+
+# --- 4. Launch Premiere and wait for the panel's WebSocket ---------------
+# Open a project along with Premiere where possible. The panel's manifest
+# starts it on ApplicationActivate, which fires once at startup -- and CEP
+# unloads the extension while no project is open, so launching to the welcome
+# screen means the panel appears and then dies, with no second auto-start.
+if ($Project) {
+    if (-not (Test-Path $Project)) { throw "Project not found: $Project" }
+    # Open via the .prproj file association rather than passing the path as an
+    # argument to the exe: PowerShell hands Premiere an extended-length
+    # "\\?\C:\..." path that way, and Premiere rejects it with "This file path
+    # does not exist on disk at this location."
+    $projectFile = (Get-Item -LiteralPath $Project).FullName
+    Write-Step "Launching Premiere Pro with $(Split-Path -Leaf $projectFile)"
+    Start-Process -FilePath $projectFile
+} else {
+    Write-Step 'Launching Premiere Pro'
+    Write-Warn 'No -Project given. Open a project promptly: the panel does not'
+    Write-Warn 'survive on the welcome screen.'
+    Start-Process $premiere
+}
+
+Write-Step 'Waiting for the MCP Bridge panel on port 9801'
+$deadline = (Get-Date).AddMinutes(3)
+$panelUp = $false
+while ((Get-Date) -lt $deadline) {
+    if (Get-NetTCPConnection -LocalPort 9801 -State Listen -ErrorAction SilentlyContinue) {
+        $panelUp = $true
+        break
+    }
+    Start-Sleep -Seconds 2
+}
+
+if (-not $panelUp) {
+    Write-Warn 'Panel did not come up within 3 minutes. In order of likelihood:'
+    Write-Warn '  1. No project open -- open one, then Window > Extensions >'
+    Write-Warn '     PremierPro MCP Bridge (auto-start only fires at launch).'
+    Write-Warn '  2. Panel opened but rendered blank -- close it, delete'
+    Write-Warn "     $env:LOCALAPPDATA\Temp\cep_cache\PPRO_*_$extensionId,"
+    Write-Warn '     then reopen it from that menu.'
+    Write-Warn "  3. Check $env:LOCALAPPDATA\Temp\CEP12-PPRO.log for"
+    Write-Warn '     "Signature verification failed" and rerun this script.'
+} else {
+    Write-Host '    Panel is listening on 9801.' -ForegroundColor Green
+}
+
+# --- 5. Start the backend services --------------------------------------
+if ($NoServices) {
+    Write-Step 'Skipping services (-NoServices)'
+    return
+}
+
+Write-Step 'Starting backend services'
+& "$PSScriptRoot\start-services-win.bat"

--- a/scripts/restore-gen-go-mod.sh
+++ b/scripts/restore-gen-go-mod.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+cat > gen/go/go.mod <<'EOF'
+module github.com/anthropics/premierpro-mcp/gen/go
+
+go 1.26.1
+
+require (
+	google.golang.org/grpc v1.79.3
+	google.golang.org/protobuf v1.36.11
+)
+
+require (
+	golang.org/x/net v0.48.0 // indirect
+	golang.org/x/sys v0.39.0 // indirect
+	golang.org/x/text v0.32.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
+)
+EOF
+
+cd gen/go && go mod tidy

--- a/scripts/start-all.sh
+++ b/scripts/start-all.sh
@@ -31,11 +31,12 @@ echo ""
 echo "Project root: $PROJECT_ROOT"
 echo ""
 
-# Clean up stale PID file
-if [ -f "$PID_FILE" ]; then
-    echo -e "${YELLOW}Cleaning up stale PID file...${NC}"
-    "$SCRIPT_DIR/stop-all.sh" 2>/dev/null || true
-fi
+# Always clean up first. Not just when a PID file exists: it is deleted on
+# every stop, so a service orphaned by a crash still holds its port and the
+# binds below would fail with EADDRINUSE. stop-all.sh sweeps the known ports
+# when it has no PID file to work from.
+echo -e "${YELLOW}Cleaning up any running services...${NC}"
+"$SCRIPT_DIR/stop-all.sh" >/dev/null 2>&1 || true
 
 # Create log directory
 mkdir -p "$LOG_DIR"

--- a/scripts/start-all.sh
+++ b/scripts/start-all.sh
@@ -46,8 +46,17 @@ mkdir -p "$LOG_DIR"
 # --- Start Rust Media Engine (port 50052) ---
 echo -e "${CYAN}[1/3] Starting Rust media engine on port 50052...${NC}"
 cd "$PROJECT_ROOT/rust-engine"
-if [ -f "target/release/rust-engine" ]; then
-    ./target/release/rust-engine --port 50052 > "$LOG_DIR/rust-engine.log" 2>&1 &
+# The crate is named premierpro-media-engine; on Windows cargo appends .exe.
+RUST_BIN=""
+for candidate in \
+    "target/release/premierpro-media-engine.exe" \
+    "target/release/premierpro-media-engine" \
+    "target/release/rust-engine.exe" \
+    "target/release/rust-engine"; do
+    if [ -f "$candidate" ]; then RUST_BIN="$candidate"; break; fi
+done
+if [ -n "$RUST_BIN" ]; then
+    "./$RUST_BIN" --port 50052 > "$LOG_DIR/rust-engine.log" 2>&1 &
 else
     cargo run --release -- --port 50052 > "$LOG_DIR/rust-engine.log" 2>&1 &
 fi

--- a/scripts/start-services-win.bat
+++ b/scripts/start-services-win.bat
@@ -1,0 +1,29 @@
+@echo off
+REM Start the PremierPro MCP backend services on Windows.
+REM
+REM Open the CEP panel in Premiere FIRST (Window > Extensions > PremierPro MCP
+REM Bridge). The panel hosts the WebSocket server on port 9801 that ts-bridge
+REM connects to as a client; if the panel is not up yet, ts-bridge starts in
+REM disconnected mode and you have to restart it.
+REM
+REM The toolchain on this machine lives outside the default install locations
+REM (portable builds), so PATH is set explicitly here rather than relying on
+REM whatever the calling shell happens to have.
+
+setlocal
+
+set "PATH=%LOCALAPPDATA%\Programs\Go\bin;%PATH%"
+set "PATH=%LOCALAPPDATA%\Programs\Python312;%LOCALAPPDATA%\Programs\Python312\Scripts;%PATH%"
+set "PATH=%LOCALAPPDATA%\Microsoft\WinGet\Links;%PATH%"
+set "PATH=%LOCALAPPDATA%\Microsoft\WinGet\Packages\OpenJS.NodeJS.LTS_Microsoft.Winget.Source_8wekyb3d8bbwe\node-v24.18.0-win-x64;%PATH%"
+set "PATH=%USERPROFILE%\.cargo\bin;%PATH%"
+set "PATH=%LOCALAPPDATA%\Microsoft\WinGet\Packages\Google.Protobuf_Microsoft.Winget.Source_8wekyb3d8bbwe\bin;%PATH%"
+REM `just` shells out to sh, which ships with Git for Windows.
+set "PATH=C:\Program Files\Git\usr\bin;%PATH%"
+
+cd /d "%~dp0.."
+
+echo Starting PremierPro MCP services (rust :50052, python :50053, ts-bridge :50054)...
+bash scripts/start-all.sh
+
+endlocal

--- a/scripts/stop-all.sh
+++ b/scripts/stop-all.sh
@@ -15,6 +15,30 @@ NC='\033[0m'
 
 TIMEOUT=5  # Seconds to wait before SIGKILL
 
+# On Git Bash/MSYS the PIDs recorded by start-all.sh are shell PIDs, not the
+# Windows PIDs of the detached services, so `kill` reports success while the
+# process keeps holding its port and the next start fails with EADDRINUSE.
+# Fall back to killing whatever owns the port instead.
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) IS_WINDOWS=1 ;;
+    *)                    IS_WINDOWS=0 ;;
+esac
+
+kill_by_port_windows() {
+    local port="$1"
+    local pids
+    pids=$(powershell.exe -NoProfile -Command \
+        "(Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue).OwningProcess" \
+        2>/dev/null | tr -d '\r')
+    [ -z "$pids" ] && return 1
+    for wpid in $pids; do
+        [ -z "$wpid" ] && continue
+        powershell.exe -NoProfile -Command \
+            "Stop-Process -Id $wpid -Force -ErrorAction SilentlyContinue" >/dev/null 2>&1
+    done
+    return 0
+}
+
 echo -e "${CYAN}========================================${NC}"
 echo -e "${CYAN}  PremierPro MCP — Stopping All Services${NC}"
 echo -e "${CYAN}========================================${NC}"
@@ -30,6 +54,16 @@ while IFS=: read -r name pid port; do
     [ -z "$name" ] && continue
 
     echo -n "Stopping $name (PID $pid, port $port)... "
+
+    if [ "$IS_WINDOWS" -eq 1 ]; then
+        kill -TERM "$pid" 2>/dev/null   # best effort for the shell-level job
+        if kill_by_port_windows "$port"; then
+            echo -e "${GREEN}stopped${NC} (port $port)"
+        else
+            echo -e "${YELLOW}already stopped${NC}"
+        fi
+        continue
+    fi
 
     if ! kill -0 "$pid" 2>/dev/null; then
         echo -e "${YELLOW}already stopped${NC}"

--- a/scripts/stop-all.sh
+++ b/scripts/stop-all.sh
@@ -15,6 +15,9 @@ NC='\033[0m'
 
 TIMEOUT=5  # Seconds to wait before SIGKILL
 
+# Ports start-all.sh binds, used to clean up orphans when .pids is gone.
+DEFAULT_PORTS="50052 50053 50054"
+
 # On Git Bash/MSYS the PIDs recorded by start-all.sh are shell PIDs, not the
 # Windows PIDs of the detached services, so `kill` reports success while the
 # process keeps holding its port and the next start fails with EADDRINUSE.
@@ -46,7 +49,22 @@ echo ""
 
 if [ ! -f "$PID_FILE" ]; then
     echo -e "${YELLOW}No PID file found at $PID_FILE${NC}"
-    echo "No services appear to be running."
+    # A missing PID file does not mean nothing is running: it is deleted on
+    # every stop, so a service orphaned by a crash or a previous stop still
+    # holds its port and would make the next start fail with EADDRINUSE.
+    # Sweep the well-known ports instead of assuming we are clean.
+    if [ "$IS_WINDOWS" -eq 1 ]; then
+        swept=0
+        for port in $DEFAULT_PORTS; do
+            if kill_by_port_windows "$port"; then
+                echo -e "  ${GREEN}freed orphaned service on port $port${NC}"
+                swept=1
+            fi
+        done
+        [ "$swept" -eq 0 ] && echo "No services appear to be running."
+    else
+        echo "No services appear to be running."
+    fi
     exit 0
 fi
 


### PR DESCRIPTION
On Windows the bridge never reached Premiere Pro. The `standalone` fallback
bridge is macOS-only (it shells out to `osascript`), so the CEP panel is the
only path there — and several bugs kept it from working. All fixes verified
against Premiere Pro 2026 on Windows 11.

**The bridge could not load its own ExtendScript**
`panel.js` resolved `core.jsx`/`premiere.jsx` via `path.join(__dirname, "host", ...)`.
Under CEP on Windows `__dirname` is the extension root, not `src/`, so it loaded
`<ext>/host/core.jsx` — a path that does not exist — and `$.evalFile()` failed
with a bare "EvalScript error." with no hint why. Now probes the known layouts
with `fs.existsSync`.

**`premiere.jsx` failed to parse entirely**
It used the reserved word `package` as an object key. ExtendScript is ES3 and
rejects it, so the whole 1.2 MB file failed to parse and every tool outside the
~14 in `core.jsx` was unavailable. Also removed non-ASCII box-drawing and
em-dash characters from comments, which the ExtendScript eng